### PR TITLE
Add an interation limit when simulating to detect combinatorial loops

### DIFF
--- a/myhdl/test/bugs/test_issue_180.py
+++ b/myhdl/test/bugs/test_issue_180.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+
+from myhdl import *
+
+times_called = 0
+
+@block
+def Demonstration():
+    a = Signal(False)
+
+    @instance
+    def poke_loop():
+        yield delay(1)
+        a.next = not a
+
+    @always(a)
+    def comb_loop():
+        global times_called
+        times_called += 1
+        a.next = not a
+        assert times_called < 1001
+
+    return (comb_loop, poke_loop)
+
+def test_issue_180():
+    demo_inst = Demonstration()
+    demo_inst.config_sim(trace=True)
+    sim = Simulation(demo_inst)
+    sim.run(10)


### PR DESCRIPTION
If the simulation runs for more than the specified number of ticks without advancing time, then declare the simulation stuck and abort. Fixes #180.
