### PR TITLE
Remove the limitation to have only one cosimulation

### DIFF
--- a/myhdl/_Cosimulation.py
+++ b/myhdl/_Cosimulation.py
@@ -34,7 +34,6 @@ _MAXLINE = 4096
 
 class _error:
     pass
-_error.MultipleCosim = "Only a single cosimulator allowed"
 _error.DuplicateSigNames = "Duplicate signal name in myhdl vpi call"
 _error.SigNotFound = "Signal not found in Cosimulation arguments"
 _error.TimeZero = "myhdl vpi call when not at time 0"
@@ -49,11 +48,6 @@ class Cosimulation(object):
 
     def __init__(self, exe="", **kwargs):
         """ Construct a cosimulation object. """
-
-        if _simulator._cosim:
-            raise CosimulationError(_error.MultipleCosim)
-        _simulator._cosim = 1
-
         rt, wt = os.pipe()
         rf, wf = os.pipe()
 
@@ -194,7 +188,3 @@ class Cosimulation(object):
         while 1:
             yield sigs
             self._hasChange = 1
-
-    def __del__(self):
-        """ Clear flag when this object destroyed - to suite unittest. """
-        _simulator._cosim = 0

--- a/myhdl/_simulator.py
+++ b/myhdl/_simulator.py
@@ -30,7 +30,6 @@ _blocks = []
 _siglist = []
 _futureEvents = []
 _time = 0
-_cosim = 0
 _tracing = 0
 _tf = None
 

--- a/myhdl/test/core/test_Cosimulation.py
+++ b/myhdl/test/core/test_Cosimulation.py
@@ -79,21 +79,6 @@ class TestCosimulation:
         with raises_kind(CosimulationError, _error.OSError):
             Cosimulation('bla -x 45')
 
-    def testNotUnique(self):
-        cosim1 = Cosimulation(exe + "cosimNotUnique", **allSigs)
-        with raises_kind(CosimulationError, _error.MultipleCosim):
-            Cosimulation(exe + "cosimNotUnique", **allSigs)
-
-    @staticmethod
-    def cosimNotUnique():
-        wt, rf = wtrf()
-        os.write(wt, b"TO 00 a 1")
-        os.read(rf, MAXLINE)
-        os.write(wt, b"FROM 00 d 1")
-        os.read(rf, MAXLINE)
-        os.write(wt, b"START")
-        os.read(rf, MAXLINE)
-
     def testFromSignals(self):
         cosim = Cosimulation(exe + "cosimFromSignals", **allSigs)
         assert cosim._fromSignames == fromSignames


### PR DESCRIPTION
This patch removes the limitation of only one cosimulation being allowed at one time. This would be useful for e.g. running both Icarus Verilog and GHDL (which I have working but haven't cleaned up as a PR yet) as sub-simulators if a project has dependencies written in both Verilog and VHDL.

There is no unit test for this, but all existing tests (except the explicit test for multiple cosimulators) pass. I have a giant integration test that is working with these changes, but I also haven't cleaned that up to publish yet.
