### PR TITLE
[FIX] fixed a couple of issues with the way classes are handled by the new block decorator

### DIFF
--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -34,7 +34,7 @@ from myhdl._extractHierarchy import (_makeMemInfo,
                                      _UserVerilogCode, _UserVhdlCode)
 from myhdl._Signal import _Signal, _isListOfSigs
 
-from weakref import WeakValueDictionary, WeakKeyDictionary
+from weakref import WeakValueDictionary
 
 class _error:
     pass
@@ -90,6 +90,31 @@ def _getCallInfo():
     return _CallInfo(name, modctxt, symdict)
 
 
+### I don't think this is the right place for uniqueifying the name.
+### This seems to me to be a conversion concern, not a block concern, and
+### there should not be the corresponding global state to be maintained here.
+### The name should be whatever it is, which is then uniqueified at
+### conversion time. Perhaps this happens already (FIXME - check and fix)
+### ~ H Gomersall 24/11/2017
+_inst_name_set = set()
+_name_set = set()
+
+def _uniqueify_name(proposed_name):
+    '''Creates a unique block name from the proposed name by appending
+    a suitable number to the end. Every name this function returns is
+    assumed to be used, so will not be returned again.
+    '''
+    n = 0
+
+    while proposed_name in _name_set:
+        proposed_name = proposed_name + '_' + str(n)
+        n += 1
+
+    _name_set.add(proposed_name)
+
+    return proposed_name
+
+
 class _bound_function_wrapper(object):
 
     def __init__(self, bound_func, srcfile, srcline):
@@ -101,14 +126,22 @@ class _bound_function_wrapper(object):
         # register the block
         myhdl._simulator._blocks.append(self)
 
+        self.name_prefix = None
         self.name = None
 
     def __call__(self, *args, **kwargs):
-        self.calls += 1
-        return _Block(self.bound_func, self, self.srcfile,
-                      self.srcline, *args, **kwargs)
 
-_name_dict = WeakKeyDictionary()
+        name = (
+            self.name_prefix + '_' + self.bound_func.__name__ +
+            str(self.calls))
+
+        self.calls += 1
+
+        # See concerns above about uniqueifying
+        name = _uniqueify_name(name)
+
+        return _Block(self.bound_func, self, name, self.srcfile,
+                      self.srcline, *args, **kwargs)
 
 class block(object):
 
@@ -133,34 +166,38 @@ class block(object):
             function_wrapper = _bound_function_wrapper(
                 bound_func, self.srcfile, self.srcline)
             self.bound_functions[bound_key] = function_wrapper
+
+            proposed_inst_name = owner.__name__ + '0'
+
+            n = 1
+            while proposed_inst_name in _inst_name_set:
+                proposed_inst_name = owner.__name__ + str(n)
+                n += 1
+
+            function_wrapper.name_prefix = proposed_inst_name
+            _inst_name_set.add(proposed_inst_name)
+
         else:
             function_wrapper = self.bound_functions[bound_key]
             bound_func = self.bound_functions[bound_key]
 
-        proposed_name = owner.__name__ + '_' + self.func.__name__ + '0'
-        n = 1
-        while proposed_name in _name_dict.values():
-            proposed_name = owner.__name__ + '_' + self.func.__name__ + str(n)
-            n += 1
-
-        function_wrapper.name = proposed_name
-        _name_dict[bound_func] = function_wrapper.name
-
         return function_wrapper
 
     def __call__(self, *args, **kwargs):
+
+        name = self.func.__name__ + str(self.calls)
         self.calls += 1
-        _name_dict[self.func] = self.func.__name__ + str(self.calls)
 
-        self.name = _name_dict[self.func]
+        # See concerns above about uniqueifying
+        name = _uniqueify_name(name)
 
-        return _Block(self.func, self, self.srcfile,
+        return _Block(self.func, self, name, self.srcfile,
                       self.srcline, *args, **kwargs)
 
 
 class _Block(object):
 
-    def __init__(self, func, deco, srcfile, srcline, *args, **kwargs):
+    def __init__(self, func, deco, name, srcfile, srcline, *args, **kwargs):
         calls = deco.calls
 
         self.func = func
@@ -174,7 +211,7 @@ class _Block(object):
         self.symdict = None
         self.sigdict = {}
         self.memdict = {}
-        self.name = self.__name__ = deco.name
+        self.name = self.__name__ = name
 
         # flatten, but keep BlockInstance objects
         self.subs = _flatten(func(*args, **kwargs))

--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -18,7 +18,7 @@
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 """ Block with the @block decorator function. """
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import inspect
 
@@ -34,6 +34,7 @@ from myhdl._extractHierarchy import (_makeMemInfo,
                                      _UserVerilogCode, _UserVhdlCode)
 from myhdl._Signal import _Signal, _isListOfSigs
 
+from weakref import WeakValueDictionary, WeakKeyDictionary
 
 class _error:
     pass
@@ -100,10 +101,14 @@ class _bound_function_wrapper(object):
         # register the block
         myhdl._simulator._blocks.append(self)
 
+        self.name = None
+
     def __call__(self, *args, **kwargs):
         self.calls += 1
         return _Block(self.bound_func, self, self.srcfile,
                       self.srcline, *args, **kwargs)
+
+_name_dict = WeakKeyDictionary()
 
 class block(object):
 
@@ -113,10 +118,12 @@ class block(object):
         self.func = func
         functools.update_wrapper(self, func)
         self.calls = 0
+        self.name = None
+
         # register the block
         myhdl._simulator._blocks.append(self)
 
-        self.bound_functions = {}
+        self.bound_functions = WeakValueDictionary()
 
     def __get__(self, instance, owner):
         bound_key = (id(instance), id(owner))
@@ -128,32 +135,34 @@ class block(object):
             self.bound_functions[bound_key] = function_wrapper
         else:
             function_wrapper = self.bound_functions[bound_key]
+            bound_func = self.bound_functions[bound_key]
+
+        proposed_name = owner.__name__ + '_' + self.func.__name__ + '0'
+        n = 1
+        while proposed_name in _name_dict.values():
+            proposed_name = owner.__name__ + '_' + self.func.__name__ + str(n)
+            n += 1
+
+        function_wrapper.name = proposed_name
+        _name_dict[bound_func] = function_wrapper.name
 
         return function_wrapper
 
     def __call__(self, *args, **kwargs):
         self.calls += 1
+        _name_dict[self.func] = self.func.__name__ + str(self.calls)
+
+        self.name = _name_dict[self.func]
+
         return _Block(self.func, self, self.srcfile,
                       self.srcline, *args, **kwargs)
-
-
-#def block(func):
-#    srcfile = inspect.getsourcefile(func)
-#    srcline = inspect.getsourcelines(func)[0]
-#
-#    print(func, type(func))
-#    @wraps(func)
-#    def deco(*args, **kwargs):
-#        deco.calls += 1
-#        return _Block(func, deco, srcfile, srcline, *args, **kwargs)
-#    deco.calls = 0
-#    return deco
 
 
 class _Block(object):
 
     def __init__(self, func, deco, srcfile, srcline, *args, **kwargs):
         calls = deco.calls
+
         self.func = func
         self.args = args
         self.kwargs = kwargs
@@ -165,7 +174,7 @@ class _Block(object):
         self.symdict = None
         self.sigdict = {}
         self.memdict = {}
-        self.name = self.__name__ = func.__name__ + '_' + str(calls)
+        self.name = self.__name__ = deco.name
 
         # flatten, but keep BlockInstance objects
         self.subs = _flatten(func(*args, **kwargs))

--- a/myhdl/test/conversion/general/test_class_defined_signals.py
+++ b/myhdl/test/conversion/general/test_class_defined_signals.py
@@ -20,8 +20,36 @@ class HDLClass(object):
 
         return do_something, assignments
 
+class InterfaceWithInstanceSignal(object):
+
+    def __init__(self):
+
+        self.internal_ins = [
+            Signal(False), Signal(False), Signal(False), Signal(False)]
+        self.internal_outs = [
+            Signal(False), Signal(False), Signal(False), Signal(False)]
+
+    @block
+    def model(self, clock, input_interface, output_interface, index):
+
+        internal_in = self.internal_ins[index]
+        internal_out = self.internal_outs[index]
+
+        @always_comb
+        def assignments():
+            internal_in.next = input_interface
+            output_interface.next = internal_out
+
+        @always(clock.posedge)
+        def do_something():
+            print('something')
+            internal_out.next = internal_in.next
+
+        return do_something, assignments
+
+
 @block
-def pipeline(clock, input_interface, output_interface):
+def different_class_pipeline(clock, input_interface, output_interface):
 
     class_inst1 = HDLClass()
     class_inst2 = HDLClass()
@@ -37,7 +65,53 @@ def pipeline(clock, input_interface, output_interface):
     return class_hdl_inst1, class_hdl_inst2
 
 @block
-def bench():
+def common_class_pipeline(clock, input_interface, output_interface):
+
+    class_inst = HDLClass()
+
+    intermediate_interface = Signal(False)
+    intermediate_interface_2 = Signal(False)
+    intermediate_interface_3 = Signal(False)
+
+    class_hdl_inst1 = class_inst.model(
+        clock, input_interface, intermediate_interface)
+
+    class_hdl_inst2 = class_inst.model(
+        clock, intermediate_interface, intermediate_interface_2)
+
+    class_hdl_inst3 = class_inst.model(
+        clock, intermediate_interface_2, intermediate_interface_3)
+
+    class_hdl_inst4 = class_inst.model(
+        clock, intermediate_interface_3, output_interface)
+
+    return class_hdl_inst1, class_hdl_inst2, class_hdl_inst3, class_hdl_inst4
+
+@block
+def interface_with_method_pipeline(clock, input_interface, output_interface):
+
+    class_inst = InterfaceWithInstanceSignal()
+
+    intermediate_interface = Signal(False)
+    intermediate_interface_2 = Signal(False)
+    intermediate_interface_3 = Signal(False)
+
+    class_hdl_inst1 = class_inst.model(
+        clock, input_interface, intermediate_interface, 0)
+
+    class_hdl_inst2 = class_inst.model(
+        clock, intermediate_interface, intermediate_interface_2, 1)
+
+    class_hdl_inst3 = class_inst.model(
+        clock, intermediate_interface_2, intermediate_interface_3, 2)
+
+    class_hdl_inst4 = class_inst.model(
+        clock, intermediate_interface_3, output_interface, 3)
+
+    return class_hdl_inst1, class_hdl_inst2, class_hdl_inst3, class_hdl_inst4
+
+@block
+def bench(class_name='different_class'):
 
     clk = Signal(False)
     reset = Signal(False)
@@ -56,11 +130,21 @@ def bench():
 
         raise StopSimulation()
 
-    pipeline_inst = pipeline(clk, input_interface, output_interface)
+    if class_name == 'common_class':
+        pipeline_inst = common_class_pipeline(
+            clk, input_interface, output_interface)
+
+    elif class_name == 'interface':
+        pipeline_inst = interface_with_method_pipeline(
+            clk, input_interface, output_interface)
+
+    elif class_name == 'different_class':
+        pipeline_inst = different_class_pipeline(
+            clk, input_interface, output_interface)
 
     return pipeline_inst, clkgen
 
-def test_multiple_class_method():
+def test_multiple_class_single_method():
 
     clock = Signal(False)
     reset = Signal(False)
@@ -68,3 +152,21 @@ def test_multiple_class_method():
     output_interface = Signal(False)
 
     assert conversion.verify(bench()) == 0
+
+def test_single_class_single_method():
+
+    clock = Signal(False)
+    reset = Signal(False)
+    input_interface = Signal(False)
+    output_interface = Signal(False)
+
+    assert conversion.verify(bench(class_name='common_class')) == 0
+
+def test_single_interface_with_single_method():
+
+    clock = Signal(False)
+    reset = Signal(False)
+    input_interface = Signal(False)
+    output_interface = Signal(False)
+
+    assert conversion.verify(bench(class_name='interface')) == 0

--- a/myhdl/test/conversion/general/test_class_defined_signals.py
+++ b/myhdl/test/conversion/general/test_class_defined_signals.py
@@ -1,0 +1,70 @@
+from myhdl import *
+
+class HDLClass(object):
+
+    @block
+    def model(self, clock, input_interface, output_interface):
+
+        internal_in = Signal(False)
+        internal_out = Signal(False)
+
+        @always_comb
+        def assignments():
+            internal_in.next = input_interface
+            output_interface.next = internal_out
+
+        @always(clock.posedge)
+        def do_something():
+            print('something')
+            internal_out.next = internal_in.next
+
+        return do_something, assignments
+
+@block
+def pipeline(clock, input_interface, output_interface):
+
+    class_inst1 = HDLClass()
+    class_inst2 = HDLClass()
+
+    intermediate_interface = Signal(False)
+
+    class_hdl_inst1 = class_inst1.model(
+        clock, input_interface, intermediate_interface)
+
+    class_hdl_inst2 = class_inst2.model(
+        clock, intermediate_interface, output_interface)
+
+    return class_hdl_inst1, class_hdl_inst2
+
+@block
+def bench():
+
+    clk = Signal(False)
+    reset = Signal(False)
+    input_interface = Signal(False)
+    output_interface = Signal(False)
+
+    N = 20
+
+    @instance
+    def clkgen():
+
+        clk.next = 0
+        for n in range(N):
+            yield delay(10)
+            clk.next = not clk
+
+        raise StopSimulation()
+
+    pipeline_inst = pipeline(clk, input_interface, output_interface)
+
+    return pipeline_inst, clkgen
+
+def test_multiple_class_method():
+
+    clock = Signal(False)
+    reset = Signal(False)
+    input_interface = Signal(False)
+    output_interface = Signal(False)
+
+    assert conversion.verify(bench()) == 0

--- a/myhdl/test/conversion/general/test_class_defined_signals.py
+++ b/myhdl/test/conversion/general/test_class_defined_signals.py
@@ -170,3 +170,4 @@ def test_single_interface_with_single_method():
     output_interface = Signal(False)
 
     assert conversion.verify(bench(class_name='interface')) == 0
+

--- a/myhdl/test/conversion/general/test_initial_values.py
+++ b/myhdl/test/conversion/general/test_initial_values.py
@@ -53,7 +53,7 @@ def initial_value_bench(initial_val, **kwargs):
     clk = Signal(bool(0))
 
     input_signal = Signal(initial_val)
-    
+
     if 'change_input_signal' in kwargs.keys():
 
         change_input_signal = kwargs['change_input_signal']
@@ -90,7 +90,7 @@ def initial_value_bench(initial_val, **kwargs):
             clk.next = not clk
 
         raise StopSimulation()
-            
+
     @always_comb
     def output_driver():
         output_signal.next = input_signal
@@ -122,7 +122,7 @@ def canonical_list_writer(output_signal_list, clk):
     def list_writer():
         for i in range(signal_list_length):
             print(str(output_signal_list[i]._val))
-            
+
     canonical_list_writer.verilog_code = '''
 always @(posedge $clk) begin: INITIAL_VALUE_LIST_BENCH_CANONICAL_LIST_WRITER_0_LIST_WRITER
     integer i;
@@ -152,10 +152,10 @@ def initial_value_list_bench(initial_vals, **kwargs):
     clk = Signal(bool(0))
 
     input_signal_list = [Signal(initial_val) for initial_val in initial_vals]
-    
+
     if len(initial_vals[0]) == 1:
         output_signal_list = [
-            Signal(intbv(not initial_val, min=0, max=2)) for 
+            Signal(intbv(not initial_val, min=0, max=2)) for
             initial_val in initial_vals]
         update_val = int(not initial_vals[0])
     else:
@@ -180,7 +180,7 @@ def initial_value_list_bench(initial_vals, **kwargs):
             clk.next = not clk
 
         raise StopSimulation()
-            
+
     @always_comb
     def output_driver():
         for i in range(signal_list_length):
@@ -214,7 +214,7 @@ def runner(initial_val, tb=initial_value_bench, **kwargs):
 
     try:
         assert conversion.verify(tb(initial_val, **kwargs)) == 0
-    
+
     finally:
         toVerilog.initial_values = pre_toVerilog_initial_values
         toVHDL.initial_values = pre_toVHDL_initial_values
@@ -236,7 +236,7 @@ def test_signed():
     '''
     min_val = -12
     max_val = 4
-    
+
     initial_val = intbv(
         randrange(min_val, max_val), min=min_val, max=max_val)
 
@@ -245,7 +245,7 @@ def test_signed():
 def test_modbv():
     '''The correct initial value should be used for modbv type signal.
     '''
-    
+
     initial_val = modbv(randrange(0, 2**10))[10:]
 
     runner(initial_val)
@@ -283,7 +283,7 @@ def test_unsigned_list():
     min_val = 0
     max_val = 34
     initial_vals = [intbv(
-        randrange(min_val, max_val), min=min_val, max=max_val) 
+        randrange(min_val, max_val), min=min_val, max=max_val)
         for each in range(10)]
 
     runner(initial_vals, tb=initial_value_list_bench)
@@ -305,7 +305,7 @@ def test_signed_list():
 
     runner(initial_vals, tb=initial_value_list_bench)
 
-    # All the same case    
+    # All the same case
     initial_vals = [intbv(
         randrange(min_val, max_val), min=min_val, max=max_val)] * 10
 
@@ -314,25 +314,25 @@ def test_signed_list():
 def test_modbv_list():
     '''The correct initial value should be used for modbv type signal lists
     '''
-    
+
     initial_vals = [
         modbv(randrange(0, 2**10))[10:] for each in range(10)]
 
     runner(initial_vals, tb=initial_value_list_bench)
 
-    # All the same case    
+    # All the same case
     initial_vals = [modbv(randrange(0, 2**10))[10:]] * 10
     runner(initial_vals, tb=initial_value_list_bench)
 
 
 def test_long_signals_list():
-    '''The correct initial value should work with wide bitwidths (i.e. >32) 
+    '''The correct initial value should work with wide bitwidths (i.e. >32)
     signal lists
     '''
     min_val = -(2**71)
     max_val = 2**71 - 1
     initial_vals = [intbv(
-        randrange(min_val, max_val), min=min_val, max=max_val) 
+        randrange(min_val, max_val), min=min_val, max=max_val)
         for each in range(10)]
 
     runner(initial_vals, tb=initial_value_list_bench)
@@ -365,7 +365,7 @@ def test_init_used():
     runner(initial_val, change_input_signal=True)
 
 #def test_init_used_list():
-#    '''It should be the _init attribute of each element in the list 
+#    '''It should be the _init attribute of each element in the list
 #    that is used for initialisation
 #
 #    It should not be the current value, which should be ignored.
@@ -373,7 +373,7 @@ def test_init_used():
 #    min_val = -34
 #    max_val = 15
 #    initial_val = [intbv(
-#        randrange(min_val, max_val), min=min_val, max=max_val) 
+#        randrange(min_val, max_val), min=min_val, max=max_val)
 #        for each in range(10)]
 #
 #    list_runner(initial_val, change_input_signal=True)

--- a/myhdl/test/conversion/general/test_listofsigs.py
+++ b/myhdl/test/conversion/general/test_listofsigs.py
@@ -13,7 +13,7 @@ M= 2**N
 @block
 def intbv2list():
     """Conversion between intbv and list of boolean signals."""
-    
+
     a = Signal(intbv(0)[N:])
     b = [Signal(bool(0)) for i in range(len(a))]
     z = Signal(intbv(0)[N:])
@@ -43,8 +43,8 @@ def intbv2list():
 
 def test_intbv2list():
     assert conversion.verify(intbv2list()) == 0
-            
-    
+
+
 ### A number of cases with relaxed constraints, for various decorator types ###
 
 @block
@@ -184,7 +184,7 @@ def case4(z, a, inv):
 @block
 def processlist(case, inv):
     """Extract list from intbv, do some processing, reassemble."""
-    
+
     a = Signal(intbv(1)[N:])
     z = Signal(intbv(0)[N:])
 
@@ -204,16 +204,16 @@ def processlist(case, inv):
 
 
 # functional tests
-    
+
 def test_processlist11():
     assert conversion.verify(processlist(case1, inv1)) == 0
-    
+
 def test_processlist12():
     assert conversion.verify(processlist(case1, inv2))== 0
-    
+
 def test_processlist22():
     assert conversion.verify(processlist(case2, inv2))== 0
-    
+
 def test_processlist33():
     assert conversion.verify(processlist(case3, inv3))== 0
 
@@ -244,7 +244,7 @@ def unsigned():
 
 def test_unsigned():
     conversion.verify(unsigned())
-        
+
 
 @block
 def signed():
@@ -267,7 +267,7 @@ def signed():
 
 def test_signed():
     conversion.verify(signed())
-        
+
 
 @block
 def mixed():
@@ -291,7 +291,7 @@ def mixed():
 
 def test_mixed():
     conversion.verify(mixed())
-        
+
 
 ### error tests
 
@@ -318,8 +318,8 @@ def test_portInList():
         assert e.kind == _error.PortInList
     else:
         assert False
-       
-    
+
+
 # signal in multiple lists
 
 @block
@@ -346,7 +346,7 @@ def test_sigInMultipleLists():
         assert False
 
 # list of signals as port
-       
+
 @block
 def my_register(clk, inp, outp):
     @always(clk.posedge)
@@ -369,4 +369,4 @@ def test_listAsPort():
 
 
 
-    
+

--- a/myhdl/test/conversion/toVHDL/test_custom.py
+++ b/myhdl/test/conversion/toVHDL/test_custom.py
@@ -18,7 +18,7 @@ ACTIVE_LOW, INACTIVE_HIGH = 0, 1
 @block
 def incRef(count, enable, clock, reset, n):
     """ Incrementer with enable.
-    
+
     count -- output
     enable -- control input, increment when 1
     clock -- clock input
@@ -52,11 +52,11 @@ def incGen(count, enable, clock, reset, n):
                     count.next = (count + 1) % n
     return logic
 
-                                        
+
 @block
 def inc(count, enable, clock, reset, n):
     """ Incrementer with enable.
-    
+
     count -- output
     enable -- control input, increment when 1
     clock -- clock input
@@ -87,14 +87,14 @@ process ($clock, $reset) begin
     end if;
 end process;
 """
-                
+
     return incProcess
 
 
 
 @block
 def incErr(count, enable, clock, reset, n):
-    
+
     @always(clock.posedge, reset.negedge)
     def incProcess():
         # make it fail in conversion
@@ -120,7 +120,7 @@ always @(posedge $clock, negedge $reset) begin
     end
 end
 """
-                
+
     return incProcess
 
 
@@ -170,12 +170,12 @@ process ($clock, $reset) begin
     end if;
 end process;
 """
-    
+
     return logic
 
 @block
 def inc2(count, enable, clock, reset, n):
-    
+
     nextCount = Signal(intbv(0, min=0, max=n))
 
     comb = inc_comb(nextCount, count, n)
@@ -188,6 +188,44 @@ def inc2(count, enable, clock, reset, n):
 def inc3(count, enable, clock, reset, n):
     inc2_inst = inc2(count, enable, clock, reset, n)
     return inc2_inst
+
+class ClassIncrementer(object):
+    @block
+    def inc(self, count, enable, clock, reset, n):
+        """ Incrementer with enable.
+
+        count -- output
+        enable -- control input, increment when 1
+        clock -- clock input
+        reset -- asynchronous reset input
+        n -- counter max value
+        """
+        @always(clock.posedge, reset.negedge)
+        def incProcess():
+            # make it fail in conversion
+            import types
+            if reset == ACTIVE_LOW:
+                count.next = 0
+            else:
+                if enable:
+                    count.next = (count + 1) % n
+
+        count.driven = "reg"
+
+        self.inc.vhdl_code = \
+    """
+    process ($clock, $reset) begin
+        if ($reset = '0') then
+            $count <= (others => '0');
+        elsif rising_edge($clock) then
+            if ($enable = '1') then
+                $count <= ($count + 1) mod $n;
+            end if;
+        end if;
+    end process;
+    """
+
+        return incProcess
 
 
 @block
@@ -265,10 +303,10 @@ def testIncRef():
 
 def testInc():
     assert conversion.verify(customBench(inc)) == 0
-    
+
 def testInc2():
     assert conversion.verify(customBench(inc2)) == 0
-    
+
 def testInc3():
     assert conversion.verify(customBench(inc3)) == 0
 
@@ -279,7 +317,7 @@ def testIncGen():
         pass
     else:
         assert False
-        
+
 def testIncErr():
     try:
         assert conversion.verify(customBench(incErr)) == 0
@@ -288,16 +326,18 @@ def testIncErr():
     else:
         assert False
 
+def testMethodInc():
+    incrementer = ClassIncrementer()
+    assert conversion.verify(customBench(incrementer.inc)) == 0
 
 
 
-    
-
-    
-        
 
 
-                
 
-        
+
+
+
+
+
 


### PR DESCRIPTION
Fixed problem with setting vhdl_code and verilog_code on class methods and added test.

There was a problem with the way a unique class proxy was created every time, so changes to that proxy (e.g. setting `vhdl_code` or `verilog_code`) would be lost immediately.

The change below fixes this by always returning the same proxy given a class instance.

A test is also implemented testing the problem which works only after the fix.

Also, fixed a problem with the way class methods are named which resulted in name collisions, notably on signal names.