### PR TITLE
Prevent verilog reset generation logic from attempting to reset TristateSignals and TristateDrivers

### DIFF
--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -1431,8 +1431,9 @@ class _ConvertAlwaysSeqVisitor(_ConvertVisitor):
             self.write("if (%s == %s) begin" % (reset, int(reset.active)))
             self.indent()
             for s in sigregs:
-                self.writeline()
-                self.write("%s <= %s;" % (s, _convertInitVal(s, s._init)))
+                if not isinstance(s, _TristateSignal) and not isinstance(s, _TristateDriver):
+                    self.writeline()
+                    self.write("%s <= %s;" % (s, _convertInitVal(s, s._init)))
             for v in varregs:
                 n, reg, init = v
                 self.writeline()


### PR DESCRIPTION
Fix for https://github.com/jandecaluwe/myhdl/issues/190
([Bug] Tristate Signals are unconvertable in @always_seq blocks with resets.)
