### PR TITLE
[FIX] Tests and fix for VHDL conversion of if/elif/else->case statements for boolean signals

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -466,14 +466,14 @@ def _writeSigDecls(f, intf, siglist, memlist):
             val_str = ""
         else:
             sig_vhdl_objs = [inferVhdlObj(each) for each in m.mem]
-            
+
             if all([each._init == m.mem[0]._init for each in m.mem]):
                 val_str = (
-                    ' := (others => %dX"%s")' % 
+                    ' := (others => %dX"%s")' %
                     (sig_vhdl_objs[0].size, str(m.mem[0]._init)))
             else:
                 _val_str = ',\n    '.join(
-                    ['%dX"%s"' % (obj.size, str(each._init)) for 
+                    ['%dX"%s"' % (obj.size, str(each._init)) for
                      obj, each in zip(sig_vhdl_objs, m.mem)])
 
                 val_str = ' := (\n    ' + _val_str + ')'
@@ -644,7 +644,10 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         return s
 
     def BitRepr(self, item, var):
-        return '"%s"' % bin(item, len(var))
+        if isinstance(var._val, bool):
+            return '\'%s\'' % bin(item, len(var))
+        else:
+            return '"%s"' % bin(item, len(var))
 
     def inferCast(self, vhd, ori):
         pre, suf = "", ""

--- a/myhdl/test/conversion/general/test_case.py
+++ b/myhdl/test/conversion/general/test_case.py
@@ -79,6 +79,39 @@ def bench_case(map_case, N):
 
     return stimulus, inst
 
+@block
+def bool_bench_case(map_case):
+
+    a = Signal(False)
+    z = Signal(intbv(0)[2:])
+
+    inst = map_case(z, a)
+
+    @instance
+    def stimulus():
+        for i in range(2):
+            a.next = i
+            yield delay(10)
+            print(z)
+
+    return stimulus, inst
+
+@block
+def length1_bench_case(map_case):
+
+    a = Signal(intbv(0)[1:])
+    z = Signal(intbv(0)[2:])
+
+    inst = map_case(z, a)
+
+    @instance
+    def stimulus():
+        for i in range(2):
+            a.next = i
+            yield delay(10)
+            print(z)
+
+    return stimulus, inst
 
 def test_case4():
     assert bench_case(map_case4, 4).verify_convert() == 0
@@ -91,3 +124,15 @@ def test_case3():
 
 def test_case4_full():
     assert bench_case(map_case4_full, 4).verify_convert() == 0
+
+def test_case2_bool():
+    assert bool_bench_case(map_case3).verify_convert() == 0
+
+def test_case3_bool():
+    assert bool_bench_case(map_case3).verify_convert() == 0
+
+def test_case2_single_bit():
+    assert length1_bench_case(map_case3).verify_convert() == 0
+
+def test_case3_single_bit():
+    assert length1_bench_case(map_case3).verify_convert() == 0


### PR DESCRIPTION
Consider the following code:

``` python
from myhdl import *

FALSE = 0
TRUE = 1

@block
def assignments(clock, test, out):

    @always(clock.posedge)
    def assign_in():
        if test == TRUE:
            out.next = 0
        elif test == FALSE:
            out.next = 1

        else:
            out.next = 0

    return assign_in

@block
def foo_block(clock, in_val, out):

    block1 = assignments(clock, in_val, out)

    return block1

clock = Signal(False)
out = Signal(False)
in_val = Signal(True)

foo = foo_block(clock, in_val, out)

foo.convert(hdl='VHDL')
```

This will convert but to code that is invalid VHDL. Specifically, the case statement looks like this:

``` vhdl
FOO_BLOCK_ASSIGNMENTS_2_ASSIGN_IN: process (clock) is
begin
    if rising_edge(clock) then
        case signal(0) is
            when "1" =>
                out2 <= '0';
            when "0" =>
                out2 <= '1';
            when others =>
                out2 <= '0';
        end case;
    end if;
end process FOO_BLOCK_ASSIGNMENTS_2_ASSIGN_IN;
```

Instead, it should be as follows (with single quotations):

``` vhdl
FOO_BLOCK_ASSIGNMENTS_2_ASSIGN_IN: process (clock) is
begin
    if rising_edge(clock) then
        case signal(0) is
            when '1' =>
                out2 <= '0';
            when '0' =>
                out2 <= '1';
            when others =>
                out2 <= '0';
        end case;
    end if;
end process FOO_BLOCK_ASSIGNMENTS_2_ASSIGN_IN;
```

Though there is invariably a work around for the problem due to it being a boolean value, this shouldn't pass quietly and there are plausible use cases where explicit naming of the cases is desirable. In addition, the logic is perfectly valid even if it's a bit clunky.

This pull request handles the boolean case explicitly and so handles the above example (as well as properly testing and handling single bit vectors).

All tests included for the desired behaviour.
