### PR TITLE
[FIX] Declare signal procedure parameters as signals

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1928,7 +1928,12 @@ class _ConvertTaskVisitor(_ConvertVisitor):
             inout = input and output
             dir = (inout and "inout") or (output and "out") or "in"
             self.writeline()
-            self.writeDeclaration(obj, name, dir=dir, constr=False, endchar="")
+            if isinstance(obj, _Signal):
+                kind = 'signal'
+            else:
+                kind = ''
+            self.writeDeclaration(obj, name, kind=kind, dir=dir,
+                                  constr=False, endchar="")
 
     def visit_FunctionDef(self, node):
         self.write("procedure %s" % self.tree.name)


### PR DESCRIPTION
#185 To fix part of issue 185 we need to declare procedure parameters

as signals if they are signals.
