### PR TITLE
Simulation configuration + progress callback

### DIFF
--- a/myhdl/_Simulation.py
+++ b/myhdl/_Simulation.py
@@ -112,7 +112,7 @@ class Simulation(object):
     def quit(self):
         self._finalize()
 
-    def run(self, duration=None, quiet=0):
+    def run(self, duration=None, quiet=0, progress_callback=None, progress_precision=0):
         """ Run the simulation for some duration.
 
         duration -- specified simulation duration (default: forever)
@@ -140,9 +140,16 @@ class Simulation(object):
         _pop = waiters.pop
         _append = waiters.append
         _extend = waiters.extend
+        self.progress = 0
+        progress_precision = 10**progress_precision
 
         while 1:
             try:
+                if progress_callback :
+                    progress = 100*progress_precision * t // maxTime
+                    if self.progress != progress :
+                         self.progress = progress
+                         progress_callback(progress/progress_precision)
 
                 for s in _siglist:
                     _extend(s._update())

--- a/myhdl/_Simulation.py
+++ b/myhdl/_Simulation.py
@@ -145,7 +145,7 @@ class Simulation(object):
 
         while 1:
             try:
-                if progress_callback :
+                if progress_callback:
                     progress = 100*progress_precision * t // maxTime
                     if self.progress != progress :
                          self.progress = progress

--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -282,13 +282,13 @@ class _Block(object):
                 setattr(myhdl.traceSignals, k, v)
             myhdl.traceSignals(self)
 
-    def run_sim(self, duration=None, quiet=0):
+    def run_sim(self, duration=None, quiet=0, progress_callback=None, progress_precision=0):
         if self.sim is None:
             sim = self
             #if self._config_sim['trace']:
             #    sim = myhdl.traceSignals(self)
             self.sim = myhdl._Simulation.Simulation(sim)
-        self.sim.run(duration, quiet)
+        self.sim.run(duration, quiet, progress_callback, progress_precision)
 
     def quit_sim(self):
         if self.sim is not None:

--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -275,9 +275,11 @@ class _Block(object):
             setattr(converter, k, v)
         return converter(self)
 
-    def config_sim(self, trace=False):
+    def config_sim(self, trace=False, **kwargs) :
         self._config_sim['trace'] = trace
         if trace:
+            for k, v in kwargs.items() :
+                setattr(myhdl.traceSignals, k, v)
             myhdl.traceSignals(self)
 
     def run_sim(self, duration=None, quiet=0):

--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -56,7 +56,8 @@ class _TraceSignalsClass(object):
                 "directory",
                 "filename",
                 "timescale",
-                "tracelists"
+                "tracelists",
+                "tracebackup"
                 )
 
     def __init__(self):
@@ -65,6 +66,7 @@ class _TraceSignalsClass(object):
         self.filename = None
         self.timescale = "1ns"
         self.tracelists = True
+        self.tracebackup = True
 
     def __call__(self, dut, *args, **kwargs):
         global _tracing, vcdpath
@@ -122,8 +124,10 @@ class _TraceSignalsClass(object):
             vcdpath = os.path.join(directory, filename + ".vcd")
 
             if path.exists(vcdpath):
-                backup = vcdpath + '.' + str(path.getmtime(vcdpath))
-                shutil.copyfile(vcdpath, backup)
+                if self.tracebackup :
+                    print("Backup")
+                    backup = vcdpath + '.' + str(path.getmtime(vcdpath))
+                    shutil.copyfile(vcdpath, backup)
                 os.remove(vcdpath)
             vcdfile = open(vcdpath, 'w')
             _simulator._tracing = 1


### PR DESCRIPTION
1) After "block" instanciation, it is not more possible to configure simulation. Re-enables this possibility.
2) Add the possibility to not create trace backup.
3) Add the possibility to pass a callback to simulation run to get progress information. 