### PR TITLE
[WIP] conversion test improvements

### DIFF
--- a/myhdl/test/conftest.py
+++ b/myhdl/test/conftest.py
@@ -39,3 +39,11 @@ def bug(issue_no, hdl='all'):
     else:
         sims = [k for k, v in _simulators.items() if v.hdl.lower() == hdl]
     return xfail(verify.simulator in sims, reason='issue '+issue_no)
+
+def pytest_pyfunc_call(pyfuncitem):
+    if 'verify_convert' in pyfuncitem.keywords:
+        funcargs = pyfuncitem.funcargs
+        testargs = {}
+        for arg in pyfuncitem._fixtureinfo.argnames:
+            testargs[arg] = funcargs[arg]
+        pyfuncitem.obj(**testargs).verify_convert()

--- a/myhdl/test/conversion/general/test_ShadowSignal.py
+++ b/myhdl/test/conversion/general/test_ShadowSignal.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
+import pytest
 import myhdl
 from myhdl import *
 
+@pytest.mark.verify_convert
 @block
-def bench_SliceSignal():
+def test_SliceSignal():
 
     s = Signal(intbv(0)[8:])
     a, b, c = s(7), s(5), s(0)
@@ -26,12 +28,9 @@ def bench_SliceSignal():
     return check
 
 
-def test_SliceSignal():
-    assert conversion.verify(bench_SliceSignal()) == 0
-
-
+@pytest.mark.verify_convert
 @block
-def bench_ConcatSignal():
+def test_ConcatSignal():
 
     a = Signal(intbv(0)[5:])
     b = Signal(bool(0))
@@ -59,11 +58,10 @@ def bench_ConcatSignal():
 
     return check
 
-def test_ConcatSignal():
-    assert conversion.verify(bench_ConcatSignal()) == 0
 
+@pytest.mark.verify_convert
 @block
-def bench_ConcatSignalWithConsts():
+def test_ConcatSignalWithConsts():
 
     a = Signal(intbv(0)[5:])
     b = Signal(bool(0))
@@ -101,12 +99,9 @@ def bench_ConcatSignalWithConsts():
     return check
 
 
-def test_ConcatSignalWithConsts():
-    assert conversion.verify(bench_ConcatSignalWithConsts()) == 0
-
-
+@pytest.mark.verify_convert
 @block
-def bench_TristateSignal():
+def test_TristateSignal():
     s = TristateSignal(intbv(0)[8:])
     a = s.driver()
     b = s.driver()
@@ -137,10 +132,6 @@ def bench_TristateSignal():
     return check
 
 
-def test_TristateSignal():
-    assert conversion.verify(bench_TristateSignal()) == 0
-
-
 @block
 def permute(x, a, mapping):
 
@@ -155,8 +146,9 @@ def permute(x, a, mapping):
     return assign
 
 
+@pytest.mark.verify_convert
 @block
-def bench_permute(conv=False):
+def test_permute(conv=False):
 
     x = Signal(intbv(0)[3:])
     a = Signal(intbv(0)[3:])
@@ -179,9 +171,3 @@ def bench_permute(conv=False):
         raise StopSimulation()
 
     return dut, stimulus
-
-def test_permute():
-    assert conversion.verify(bench_permute()) == 0
-
-bench_permute(toVHDL)
-bench_permute(toVerilog)

--- a/myhdl/test/conversion/general/test_adapter.py
+++ b/myhdl/test/conversion/general/test_adapter.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+import pytest
+
 import myhdl
 from myhdl import *
 
@@ -36,8 +38,9 @@ def adapter(o_err, i_err, o_spec, i_spec):
     return assign
 
 
+@pytest.mark.verify_convert
 @block
-def bench_adapter(hdl=None):
+def test_adapter(hdl=None):
     o_spec = ('c', 'a', 'other', 'nomatch')
     i_spec = { 'a' : 1, 'b' : 2, 'c' : 0, 'd' : 3, 'e' : 4, 'f' : 5, }
 
@@ -62,10 +65,3 @@ def bench_adapter(hdl=None):
             print(o_err)
 
     return dut, stimulus
-
-def test_adapter():
-    assert bench_adapter().verify_convert() == 0
-
-
-bench_adapter('Verilog')
-bench_adapter('VHDL')

--- a/myhdl/test/conversion/general/test_bin2gray.py
+++ b/myhdl/test/conversion/general/test_bin2gray.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 import os
 path = os.path
 
+import pytest
+
 from myhdl import block, Signal, intbv, delay, instance, always_comb
 
 @block
@@ -43,8 +45,13 @@ def bin2gray(B, G, width):
     return logic
 
 
+@pytest.mark.parametrize('width, bin2gray', [
+    (8, bin2gray),
+    (8, bin2gray2)
+])
+@pytest.mark.verify_convert
 @block
-def bin2grayBench(width, bin2gray):
+def test_bin2gray(width, bin2gray):
 
     B = Signal(intbv(0)[width:])
     G = Signal(intbv(0)[width:])
@@ -64,10 +71,3 @@ def bin2grayBench(width, bin2gray):
             print("%d" % G)
 
     return stimulus, bin2gray_inst
-
-
-def test1():
-     assert bin2grayBench(width=8, bin2gray=bin2gray).verify_convert() == 0
-
-def test2():
-    assert bin2grayBench(width=8, bin2gray=bin2gray2).verify_convert() == 0

--- a/myhdl/test/conversion/general/test_case.py
+++ b/myhdl/test/conversion/general/test_case.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import pytest
 import myhdl
 from myhdl import *
 
@@ -62,8 +63,15 @@ def map_case4_full(z, a):
     return logic
 
 
+@pytest.mark.parametrize('map_case, N', [
+    (map_case4, 4),
+    (map_case2, 2),
+    (map_case3, 3),
+    (map_case4_full, 4)
+])
+@pytest.mark.verify_convert
 @block
-def bench_case(map_case, N):
+def test_case(map_case, N):
 
     a = Signal(intbv(0)[2:])
     z = Signal(intbv(0)[2:])
@@ -78,16 +86,3 @@ def bench_case(map_case, N):
             print(z)
 
     return stimulus, inst
-
-
-def test_case4():
-    assert bench_case(map_case4, 4).verify_convert() == 0
-
-def test_case2():
-    assert bench_case(map_case2, 2).verify_convert() == 0
-
-def test_case3():
-    assert bench_case(map_case3, 3).verify_convert() == 0
-
-def test_case4_full():
-    assert bench_case(map_case4_full, 4).verify_convert() == 0

--- a/myhdl/test/conversion/general/test_dec.py
+++ b/myhdl/test/conversion/general/test_dec.py
@@ -5,6 +5,8 @@ import random
 from random import randrange
 random.seed(2)
 
+import pytest
+
 import myhdl
 from myhdl import *
 
@@ -131,8 +133,10 @@ def decTaskFreeVar(count, enable, clock, reset, n):
     return decTaskGen
 
 
+@pytest.mark.parametrize('dec', [dec, decRef, decFunc, decFunc])
+@pytest.mark.verify_convert
 @block
-def DecBench(dec):
+def test_dec(dec):
 
     m = 8
     n = 2 ** (m-1)
@@ -179,41 +183,3 @@ def DecBench(dec):
     dec_inst = dec(count, enable, clock, reset, n=n)
 
     return dec_inst, clockGen, stimulus, check
-
-
-def testDecRef():
-    assert DecBench(decRef).verify_convert() == 0
-
-def testDec():
-    assert DecBench(dec).verify_convert() == 0
-
-def testDecFunc():
-    assert DecBench(decFunc).verify_convert() == 0
-
-def testDecTask():
-    assert DecBench(decTask).verify_convert() == 0
-
-
-## def testDecTaskFreeVar():
-##     assert verify(DecBench, decTaskFreeVar) == 0
-
-##     def testDecRef(self):
-##         sim = self.bench(decRef)
-##         sim.run(quiet=1)
-
-##     def testDec(self):
-##         sim = self.bench(dec)
-##         sim.run(quiet=1)
-
-##     def testDecFunc(self):
-##         sim = self.bench(decFunc)
-##         sim.run(quiet=1)
-
-## signed inout in task doesn't work yet in Icarus
-##     def testDecTask(self):
-##         sim = self.bench(decTask)
-##         sim.run(quiet=1)
-
-##     def testDecTaskFreeVar(self):
-##         sim = self.bench(decTaskFreeVar)
-##         sim.run(quiet=1)

--- a/myhdl/test/conversion/general/test_errors.py
+++ b/myhdl/test/conversion/general/test_errors.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import pytest
 import myhdl
 from myhdl import *
 from myhdl import ConversionError
@@ -16,12 +17,10 @@ def sigAugmAssignUnsupported(z, a):
 def test_SigAugmAssignUnsupported():
     z = Signal(intbv(0)[8:])
     a = Signal(intbv(0)[8:])
-    try:
-        verify(sigAugmAssignUnsupported(z, a))
-    except ConversionError as e:
-        assert e.kind == _error.NotSupported
-    else:
-        assert False
+    with pytest.raises(ConversionError) as e:
+        sigAugmAssignUnsupported(z, a).verify_convert()
+    assert e.value.kind == _error.NotSupported
+
 
 @block
 def modbvRange(z, a, b):
@@ -36,12 +35,9 @@ def test_modbvRange():
     z = Signal(intbv(0)[8:])
     a = Signal(intbv(0)[4:])
     b = Signal(intbv(0)[4:])
-    try:
-        verify(modbvRange(z, a, b))
-    except ConversionError as e:
-        assert e.kind == _error.ModbvRange
-    else:
-        assert False
+    with pytest.raises(ConversionError) as e:
+        modbvRange(z, a, b).verify_convert()
+    assert e.value.kind == _error.ModbvRange
 
 @block
 def modbvSigRange(z, a, b):
@@ -54,9 +50,7 @@ def test_modbvSigRange():
     z = Signal(modbv(0, min=0, max=42))
     a = Signal(intbv(0)[4:])
     b = Signal(intbv(0)[4:])
-    try:
-        verify(modbvSigRange(z, a, b))
-    except ConversionError as e:
-        assert e.kind == _error.ModbvRange
-    else:
-        assert False
+
+    with pytest.raises(ConversionError) as e:
+        modbvSigRange(z, a, b).verify_convert()
+    assert e.value.kind == _error.ModbvRange

--- a/myhdl/test/conversion/general/test_fsm.py
+++ b/myhdl/test/conversion/general/test_fsm.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 import os
 path = os.path
 
+import pytest
+
 import myhdl
 from myhdl import *
 
@@ -56,8 +58,10 @@ def FramerCtrl(SOF, state, syncFlag, clk, reset_n, t_State):
 
     return FSM
 
+
+@pytest.mark.verify_convert
 @block
-def FSMBench(FramerCtrl, t_State):
+def test_fsmFSMBench(FramerCtrl=FramerCtrl, t_State=t_State_b):
 
     SOF = Signal(bool(0))
     SOF_v = Signal(bool(0))
@@ -107,7 +111,3 @@ def FSMBench(FramerCtrl, t_State):
             # print state
 
     return framerctrl_inst,  clkgen, stimulus, check
-
-
-def test():
-    assert FSMBench(FramerCtrl, t_State_b).verify_convert() == 0

--- a/myhdl/test/conversion/general/test_hec.py
+++ b/myhdl/test/conversion/general/test_hec.py
@@ -3,6 +3,8 @@ import os
 path = os.path
 from random import randrange
 
+import pytest
+
 import myhdl
 from myhdl import *
 
@@ -125,8 +127,10 @@ headers = [ 0x00000000,
 headers.extend([randrange(2**32-1) for i in range(10)])
 headers = tuple(headers)
 
+@pytest.mark.parametrize('HecCalculator', [HecCalculatorPlain])
+@pytest.mark.verify_convert
 @block
-def HecBench(HecCalculator):
+def test_hec(HecCalculator):
 
     hec = Signal(intbv(0)[8:])
     hec_v = Signal(intbv(0)[8:])
@@ -158,6 +162,3 @@ def HecBench(HecCalculator):
 ## def testTask2(self):
 ##     sim = self.bench(HecCalculatorTask2)
 ##     Simulation(sim).run()
-
-def testPlain():
-    assert HecBench(HecCalculatorPlain).verify_convert() == 0

--- a/myhdl/test/conversion/general/test_inc.py
+++ b/myhdl/test/conversion/general/test_inc.py
@@ -6,6 +6,8 @@ import random
 from random import randrange
 random.seed(2)
 
+import pytest
+
 import myhdl
 from myhdl import *
 from myhdl.conversion import verify
@@ -133,8 +135,10 @@ def incTaskFreeVar(count, enable, clock, reset, n):
     return incTaskGen
 
 
+@pytest.mark.parametrize('inc', [inc, inc2, incRef, incTask, incFunc])
+@pytest.mark.verify_convert
 @block
-def IncBench(inc):
+def test_inc(inc):
 
     NR_CYCLES = 201
       
@@ -168,21 +172,3 @@ def IncBench(inc):
             print(count)
 
     return inc_inst, clockgen, monitor
-
-
-def test_incReg():  
-    assert verify(IncBench(incRef)) == 0
-    
-def test_inc():  
-    assert verify(IncBench(inc)) == 0
-    
-def test_inc2():  
-    assert verify(IncBench(inc2)) == 0
-    
-def testIncTask():
-    assert verify(IncBench(incTask)) == 0
-    
-def testIncFunc():
-    assert verify(IncBench(incFunc)) == 0
-    
-

--- a/myhdl/test/conversion/general/test_intbv_signed.py
+++ b/myhdl/test/conversion/general/test_intbv_signed.py
@@ -21,11 +21,14 @@
 """ Run the intbv.signed() unit tests. """
 from __future__ import absolute_import
 
+import pytest
+
 import myhdl
 from myhdl import *
 
+@pytest.mark.verify_convert
 @block
-def PlainIntbv():
+def test_PlainIntbv():
     '''Test a plain intbv instance with .signed() 
 
     ----+----+----+----+----+----+----+----
@@ -198,8 +201,9 @@ def PlainIntbv():
 
 
 
+@pytest.mark.verify_convert
 @block
-def SlicedSigned():
+def test_SlicedSigned():
     '''Test a slice with .signed()
 
     This test can actually be simplified, as a slice will always have
@@ -225,8 +229,9 @@ def SlicedSigned():
     return logic
 
 
+@pytest.mark.verify_convert
 @block
-def SignedConcat():
+def test_SignedConcat():
     '''Test the .signed() function with the concatenate function'''
 
     @instance
@@ -248,13 +253,3 @@ def SignedConcat():
         assert concat(b, True, True).signed() == -9
         
     return logic
-
-def test_PlainIntbv():
-    assert conversion.verify(PlainIntbv()) == 0
-    
-def test_SlicedSigned():
-    assert conversion.verify(SlicedSigned()) == 0
-    
-def test_SignedConcat():
-    assert conversion.verify(SignedConcat()) == 0
-    

--- a/myhdl/test/conversion/general/test_interfaces1.py
+++ b/myhdl/test/conversion/general/test_interfaces1.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import sys
 
+import pytest
+
 import myhdl
 from myhdl import *
 from myhdl import ConversionError
@@ -35,8 +37,9 @@ def m_two_level(clock,reset,ia,ib):
 
     return g_one, rtl
 
+@pytest.mark.verify_convert
 @block
-def c_testbench_one():
+def test_one_level():
     clock = Signal(bool(0))
     reset = ResetSignal(0,active=0,async=True)
     ia = MyIntf()
@@ -67,8 +70,9 @@ def c_testbench_one():
 
     return tb_dut, tb_clk, tb_stim
 
+@pytest.mark.verify_convert
 @block
-def c_testbench_two():
+def test_two_level():
     clock = Signal(bool(0))
     reset = ResetSignal(0,active=0,async=True)
     ia = MyIntf()
@@ -98,27 +102,6 @@ def c_testbench_two():
         raise StopSimulation
 
     return tb_dut, tb_clk, tb_stim
-
-def test_one_level_analyze():
-    clock = Signal(bool(0))
-    reset = ResetSignal(0,active=0,async=True)
-    ia = MyIntf()
-    ib = MyIntf()
-    analyze(m_one_level(clock,reset,ia,ib))
-
-def test_one_level_verify():
-    assert verify(c_testbench_one()) == 0
-
-def test_two_level_analyze():
-    clock = Signal(bool(0))
-    reset = ResetSignal(0,active=0,async=True)
-    ia = MyIntf()
-    ib = MyIntf()
-    analyze(m_two_level(clock,reset,ia,ib))
-
-def test_two_level_verify():
-    assert verify(c_testbench_two()) == 0
-
 
 if __name__ == '__main__':
     print(sys.argv[1])

--- a/myhdl/test/conversion/general/test_interfaces2.py
+++ b/myhdl/test/conversion/general/test_interfaces2.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import sys
 
+import pytest
+
 import myhdl
 from myhdl import *
 from myhdl.conversion import analyze,verify
@@ -81,8 +83,9 @@ def test_name_conflict_after_replace():
     a_x = Signal(intbv(0)[len(a.x):])
     assert conversion.analyze(name_conflict_after_replace(clock, reset, a, a_x)) == 0
 
+@pytest.mark.verify_convert
 @block
-def c_testbench():
+def test_name_conflicts():
     clock = Signal(bool(0))
     reset = ResetSignal(0, active=0, async=False)
     a,b,c = (Intf(),Intf(),Intf(),)
@@ -113,14 +116,6 @@ def c_testbench():
 
     return tb_dut,tb_clk,tb_stim
 
-def test_name_conflicts_analyze():
-    clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=False)
-    a,b,c = (Intf(),Intf(),Intf(),)
-    analyze(m_test_intf(clock,reset,a,b,c))
-
-def test_name_conflicts_verify():
-    assert verify(c_testbench()) == 0
 
 if __name__ == '__main__':
     verify.simulator = analyze.simulator = sys.argv[1]

--- a/myhdl/test/conversion/general/test_interfaces3.py
+++ b/myhdl/test/conversion/general/test_interfaces3.py
@@ -72,8 +72,9 @@ def m_assign_intf(x, y):
         x.x.next = y.y
     return rtl
 
+@pytest.mark.verify_convert
 @block
-def c_testbench_one():
+def test_top_assign():
     x,y,z = [Signal(intbv(0, min=-8, max=8))
              for _ in range(3)]
 
@@ -107,8 +108,9 @@ def m_multi_comb(x, y, z):
         x.x.next = y.y + z.z.z
     return rtl
 
+@pytest.mark.verify_convert
 @block
-def c_testbench_two():
+def test_multi_comb():
     x,y,z = [Signal(intbv(0, min=-8, max=8))
              for _ in range(3)]
     tb_dut = m_top_multi_comb(x,y,z)
@@ -138,8 +140,9 @@ def m_top_const(clock, reset, x, y, intf):
 
     return rtl1, rtl2
 
+@pytest.mark.verify_convert
 @block
-def c_testbench_three():
+def test_top_const():
     """
     this will test the use of constants in an inteface
     as well as top-level interface conversion.
@@ -173,58 +176,3 @@ def c_testbench_three():
         raise StopSimulation
 
     return tbdut, tbclk, tbstim
-
-def test_one_analyze():
-    x,y,z = [Signal(intbv(0, min=-8, max=8))
-             for _ in range(3)]
-    # fool name check in convertor 
-    # to be reviewed
-    x._name = 'x'
-    y._name = 'y'
-    z._name = 'z'
-    analyze(m_top_assign(x, y, z))
-
-def test_one_verify():
-    assert verify(c_testbench_one()) == 0
-
-def test_two_analyze():
-    x,y,z = [Signal(intbv(0, min=-8, max=8))
-             for _ in range(3)]
-    # fool name check in convertor 
-    # to be reviewed
-    x._name = 'x'
-    y._name = 'y'
-    z._name = 'z'
-    analyze(m_top_multi_comb(x, y, z))
-
-def test_two_verify():
-    assert verify(c_testbench_two()) == 0
-
-def test_three_analyze():
-    clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
-    x = Signal(intbv(3, min=-5000, max=5000))
-    y = Signal(intbv(4, min=-200, max=200))
-    intf = IntfWithConstant2()
-    analyze(m_top_const(clock, reset, x, y, intf))
-
-def test_three_verify():
-    assert verify(c_testbench_three()) == 0
-
-
-if __name__ == '__main__':
-    print(sys.argv[1])
-    verify.simulator = analyze.simulator = sys.argv[1]
-    print("*** verify myhdl simulation")    
-    Simulation(c_testbench_one()).run()
-    Simulation(c_testbench_two()).run()
-    Simulation(c_testbench_three()).run()
-    print("*** myhdl simulation ok")    
-    print("")
-
-    print("*** myhdl verify conversion")    
-    print(verify(c_testbench_one))
-    print(verify(c_testbench_two))  
-    print(verify(c_testbench_three))  
-    print("*** myhdl conversion ok")      
-    print("")

--- a/myhdl/test/conversion/general/test_interfaces4.py
+++ b/myhdl/test/conversion/general/test_interfaces4.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import sys
 
+import pytest
+
 import myhdl
 from myhdl import *
 from myhdl import ConversionError
@@ -90,8 +92,9 @@ def m_top(clock, reset, sdi, sdo):
     return g1, g2, assigns
 
 
+@pytest.mark.verify_convert
 @block
-def c_testbench_one():
+def test_top():
     """ yet another interface test.
     This test is used to expose a particular bug that was discovered
     during the development of interface conversion.  The structure
@@ -134,32 +137,6 @@ def c_testbench_one():
         raise StopSimulation
 
     return tbclk, tbstim, tbdut
-
-
-def test_one_testbench():
-    clock = Signal(bool(0))
-    reset = ResetSignal(0, active=1, async=False)
-    sdi = Signal(bool(0))
-    sdo = Signal(bool(0))
-    Simulation(c_testbench_one()).run()
-
-
-def test_one_analyze():
-    clock = Signal(bool(0))
-    reset = ResetSignal(0, active=1, async=False)
-    sdi = Signal(bool(0))
-    sdo = Signal(bool(0))
-    analyze(m_top(clock, reset, sdi, sdo))
-
-
-def test_one_verify():
-    assert verify(c_testbench_one()) == 0
-
-
-def test_conversion():
-    toVerilog(c_testbench_one())
-    toVHDL(c_testbench_one())
-
 
 if __name__ == '__main__':
     print(sys.argv[1])

--- a/myhdl/test/conversion/general/test_listofsigs.py
+++ b/myhdl/test/conversion/general/test_listofsigs.py
@@ -285,12 +285,9 @@ def portInList(z, a, b):
 def test_portInList():
     z, a, b = [Signal(intbv(0)[8:]) for i in range(3)]
 
-    try:
-        inst = conversion.analyze(portInList(z, a, b))
-    except ConversionError as e:
-        assert e.kind == _error.PortInList
-    else:
-        assert False
+    with pytest.raises(ConversionError) as e:
+        portInList(z, a, b).analyze_convert()
+    assert e.value.kind == _error.PortInList
        
     
 # signal in multiple lists
@@ -311,12 +308,9 @@ def sigInMultipleLists():
 
 def test_sigInMultipleLists():
 
-    try:
-        inst = conversion.analyze(sigInMultipleLists())
-    except ConversionError as e:
-        assert e.kind == _error.SignalInMultipleLists
-    else:
-        assert False
+    with pytest.raises(ConversionError) as e:
+        sigInMultipleLists().analyze_convert()
+    assert e.value.kind == _error.SignalInMultipleLists
 
 # list of signals as port
        
@@ -333,9 +327,6 @@ def test_listAsPort():
     clk = Signal(False)
     inp = [Signal(intbv(0)[8:0]) for index in range(count)]
     outp = [Signal(intbv(0)[8:0]) for index in range(count)]
-    try:
+    with pytest.raises(ConversionError) as e:
         inst = conversion.analyze(my_register(clk, inp, outp))
-    except ConversionError as e:
-        assert e.kind == _error.ListAsPort
-    else:
-        assert False
+    assert e.value.kind == _error.ListAsPort

--- a/myhdl/test/conversion/general/test_listofsigs.py
+++ b/myhdl/test/conversion/general/test_listofsigs.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import pytest
 import myhdl
 from myhdl import *
 from myhdl import ConversionError
@@ -10,8 +11,9 @@ M= 2**N
 
 ### A first case that already worked with 5.0 list of signal constraints ###
 
+@pytest.mark.verify_convert
 @block
-def intbv2list():
+def test_intbv2list():
     """Conversion between intbv and list of boolean signals."""
     
     a = Signal(intbv(0)[N:])
@@ -39,11 +41,6 @@ def intbv2list():
 
     return extract, assemble, stimulus
 
-# test
-
-def test_intbv2list():
-    assert conversion.verify(intbv2list()) == 0
-            
     
 ### A number of cases with relaxed constraints, for various decorator types ###
 
@@ -177,12 +174,16 @@ def case4(z, a, inv):
     return extract, inst, assemble
 
 
-
-
-
-
+@pytest.mark.parametrize('case, inv', [
+    (case1, inv1),
+    (case1, inv2),
+    (case2, inv2),
+    (case3, inv3),
+    (case4, inv4)
+])
+@pytest.mark.verify_convert
 @block
-def processlist(case, inv):
+def test_processlist(case, inv):
     """Extract list from intbv, do some processing, reassemble."""
     
     a = Signal(intbv(1)[N:])
@@ -203,28 +204,10 @@ def processlist(case, inv):
     return case_inst, stimulus
 
 
-# functional tests
-    
-def test_processlist11():
-    assert conversion.verify(processlist(case1, inv1)) == 0
-    
-def test_processlist12():
-    assert conversion.verify(processlist(case1, inv2))== 0
-    
-def test_processlist22():
-    assert conversion.verify(processlist(case2, inv2))== 0
-    
-def test_processlist33():
-    assert conversion.verify(processlist(case3, inv3))== 0
-
-def test_processlist44():
-    assert conversion.verify(processlist(case4, inv4))== 0
-
-
-
 # signed and unsigned
+@pytest.mark.verify_convert
 @block
-def unsigned():
+def test_unsigned():
     z = Signal(intbv(0)[8:])
     a = [Signal(intbv(0)[8:]) for i in range(3)]
 
@@ -240,14 +223,11 @@ def unsigned():
         print(z)
 
     return logic, stimulus
-
-
-def test_unsigned():
-    conversion.verify(unsigned())
         
 
+@pytest.mark.verify_convert
 @block
-def signed():
+def test_signed():
     z = Signal(intbv(0, min=-10, max=34))
     a = [Signal(intbv(0, min=-5, max=17)) for i in range(3)]
 
@@ -265,12 +245,9 @@ def signed():
     return logic, stimulus
 
 
-def test_signed():
-    conversion.verify(signed())
-        
-
+@pytest.mark.verify_convert
 @block
-def mixed():
+def test_mixed():
     z = Signal(intbv(0, min=0, max=34))
     a = [Signal(intbv(0, min=-11, max=17)) for i in range(3)]
     b = [Signal(intbv(0)[5:]) for i in range(3)]
@@ -287,10 +264,6 @@ def mixed():
         print(z)
 
     return logic, stimulus
-
-
-def test_mixed():
-    conversion.verify(mixed())
         
 
 ### error tests
@@ -366,7 +339,3 @@ def test_listAsPort():
         assert e.kind == _error.ListAsPort
     else:
         assert False
-
-
-
-    

--- a/myhdl/test/conversion/general/test_loops.py
+++ b/myhdl/test/conversion/general/test_loops.py
@@ -323,20 +323,14 @@ def test_loop(LoopTest):
 
 
 def testForLoopError1():
-    try:
-        analyze(test_loop(ForLoopError1))
-    except ConversionError as e:
-        assert e.kind == _error.Requirement
-    else:
-        assert False
+    with pytest.raises(ConversionError) as e:
+        test_loop(ForLoopError1).analyze_convert()
+    assert e.value.kind == _error.Requirement
     
 def testForLoopError2():
-    try:
+    with pytest.raises(ConversionError) as e:
         analyze(test_loop(ForLoopError2))
-    except ConversionError as e:
-        assert e.kind == _error.Requirement
-    else:
-        assert False
+    assert e.value.kind == _error.Requirement
 
 # for loop 3 and 6 can't work in vhdl
 lc = [ForLoop1, ForLoop2, ForLoop4, ForLoop5, ForContinueLoop, ForBreakLoop,

--- a/myhdl/test/conversion/general/test_loops.py
+++ b/myhdl/test/conversion/general/test_loops.py
@@ -3,6 +3,7 @@ import os
 path = os.path
 from random import randrange
 
+import pytest
 
 import myhdl
 from myhdl import *
@@ -295,8 +296,15 @@ def WhileBreakContinueLoop(a, out):
                 break
     return logic
     
+# for loop 3 and 6 can't work in vhdl
+loops = [ForLoop1, ForLoop2, ForLoop4, ForLoop5, ForContinueLoop, ForBreakLoop,
+      ForBreakContinueLoop, NestedForLoop1, NestedForLoop2, FunctionCall,
+      WhileLoop, WhileContinueLoop, WhileBreakLoop, WhileBreakContinueLoop]
+
+@pytest.mark.parametrize('LoopTest', loops)
+@pytest.mark.verify_convert
 @block
-def LoopBench(LoopTest):
+def test_loop(LoopTest):
 
     a = Signal(intbv(-1)[16:])
     z = Signal(intbv(0)[16:])
@@ -316,7 +324,7 @@ def LoopBench(LoopTest):
 
 def testForLoopError1():
     try:
-        analyze(LoopBench(ForLoopError1))
+        analyze(test_loop(ForLoopError1))
     except ConversionError as e:
         assert e.kind == _error.Requirement
     else:
@@ -324,53 +332,18 @@ def testForLoopError1():
     
 def testForLoopError2():
     try:
-        analyze(LoopBench(ForLoopError2))
+        analyze(test_loop(ForLoopError2))
     except ConversionError as e:
         assert e.kind == _error.Requirement
     else:
         assert False
 
-def testForLoop1():
-    assert verify(LoopBench(ForLoop1)) == 0
-def testForLoop2():
-    assert verify(LoopBench(ForLoop2)) == 0
-def testForLoop4():
-    assert verify(LoopBench(ForLoop4)) == 0
-def testForLoop5():
-    assert verify(LoopBench(ForLoop5)) == 0
-
 # for loop 3 and 6 can't work in vhdl
+lc = [ForLoop1, ForLoop2, ForLoop4, ForLoop5, ForContinueLoop, ForBreakLoop,
+      ForBreakContinueLoop, NestedForLoop1, NestedForLoop2, FunctionCall,
+      WhileLoop, WhileContinueLoop, WhileBreakLoop, WhileBreakContinueLoop]
 
-def testForContinueLoop():
-  assert verify(LoopBench(ForContinueLoop)) == 0
-
-def testForBreakLoop():
-   assert verify(LoopBench(ForBreakLoop)) == 0
-
-def testForBreakContinueLoop():
-   assert verify(LoopBench(ForBreakContinueLoop))== 0
-
-def testNestedForLoop1():
-   assert verify(LoopBench(NestedForLoop1)) == 0
-
-def testNestedForLoop2():
-   assert verify(LoopBench(NestedForLoop2)) == 0
-
-def testWhileLoop():
-    assert verify(LoopBench(FunctionCall)) == 0
 
 ## def testTaskCall(self):
 ##     sim = self.bench(TaskCall)
 ##     Simulation(sim).run()
-
-def testWhileLoop():
-    assert verify(LoopBench(WhileLoop)) == 0
-
-def testWhileContinueLoop():
-    assert verify(LoopBench(WhileContinueLoop)) == 0
-
-def testWhileBreakLoop():
-    assert verify(LoopBench(WhileBreakLoop)) == 0
-
-def testWhileBreakContinueLoop():
-    assert verify(LoopBench(WhileBreakContinueLoop)) == 0

--- a/myhdl/test/conversion/general/test_method.py
+++ b/myhdl/test/conversion/general/test_method.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import sys
+import pytest
 import myhdl
 from myhdl import *
 from myhdl.conversion import verify
@@ -96,8 +97,10 @@ class HdlObjAttr(object):
 
         return hdl, ifx
 
+@pytest.mark.parametrize('hObj', [HdlObj, HdlObjObj, HdlObjAttrSimple])
+@pytest.mark.verify_convert
 @block
-def ObjBench(hObj):
+def test_Obj(hObj):
 
     clk = Signal(False)
     srst = Signal(False)
@@ -150,16 +153,6 @@ def ObjBench(hObj):
         raise StopSimulation
 
     return hdl_inst, tb_clkgen, tb_stimulus
-
-
-def test_hdlobj():
-    assert verify(ObjBench(HdlObj)) == 0
-    
-def test_hdlobjobj():
-    assert verify(ObjBench(HdlObjObj)) == 0
-
-def test_hdlobjattrsimple():
-    assert verify(ObjBench(HdlObjAttrSimple)) == 0
     
 #def test_hdlobjattr():
 #    # object attributes currently not supported, these 

--- a/myhdl/test/conversion/general/test_nonlocal.py
+++ b/myhdl/test/conversion/general/test_nonlocal.py
@@ -2,11 +2,15 @@ from __future__ import absolute_import
 import os
 path = os.path
 
+import pytest
+
 import myhdl
 from myhdl import *
 
 
-def NonlocalBench():
+@pytest.mark.verify_convert
+@block
+def test_nonlocal():
 
     ALL_ONES = 2**7-1
     ONE = 1
@@ -57,9 +61,3 @@ def NonlocalBench():
         raise StopSimulation()
         
     return scrambler, clkgen, stimulus
-
-
-
-def test_nonlocal():
-    assert conversion.verify(NonlocalBench) == 0
-

--- a/myhdl/test/conversion/general/test_numass.py
+++ b/myhdl/test/conversion/general/test_numass.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import
 from random import randrange
 
+import pytest
+
 import myhdl
 from myhdl import *
 
 
+@pytest.mark.verify_convert
 @block
-def NumassBench():
+def test_numass():
 
     p = Signal(intbv(1)[8:])
     q = Signal(intbv(1)[40:])
@@ -49,7 +52,3 @@ def NumassBench():
         print("%d %d %d %d %d %d" % (p, q[40:20], q[20:0], r ,s[41:20], s[20:0]))
 
     return check
-
-
-def test_numass():
-    assert conversion.verify(NumassBench()) == 0

--- a/myhdl/test/conversion/general/test_print.py
+++ b/myhdl/test/conversion/general/test_print.py
@@ -121,12 +121,9 @@ def PrintError1():
      return logic
 
 def testPrintError1():
-    try:
+    with pytest.raises(ConversionError) as e:
         conversion.verify(PrintError1)
-    except ConversionError as e:
-        assert e.kind == _error.UnsupportedFormatString
-    else:
-        assert False
+    assert e.value.kind == _error.UnsupportedFormatString
 
 def PrintError2():
      @instance
@@ -137,12 +134,9 @@ def PrintError2():
      return logic
 
 def testPrintError2():
-    try:
+    with pytest.raises(ConversionError) as e:
         conversion.verify(PrintError2)
-    except ConversionError as e:
-        assert e.kind == _error.FormatString
-    else:
-        assert False
+    assert e.value.kind == _error.FormatString
 
 def PrintError3():
      @instance
@@ -154,12 +148,9 @@ def PrintError3():
      return logic
 
 def testPrintError3():
-    try:
+    with pytest.raises(ConversionError) as e:
         conversion.verify(PrintError3)
-    except ConversionError as e:
-        assert e.kind == _error.FormatString
-    else:
-        assert False
+    assert e.value.kind == _error.FormatString
 
 def PrintError4():
      @instance
@@ -170,12 +161,9 @@ def PrintError4():
      return logic
 
 def testPrintError4():
-    try:
+    with pytest.raises(ConversionError) as e:
         conversion.verify(PrintError4)
-    except ConversionError as e:
-        assert e.kind == _error.UnsupportedFormatString
-    else:
-        assert False
+    assert e.value.kind == _error.UnsupportedFormatString
 
 def PrintError5():
      @instance
@@ -186,9 +174,6 @@ def PrintError5():
      return logic
 
 def testPrintError5():
-    try:
+    with pytest.raises(ConversionError) as e:
         conversion.verify(PrintError5)
-    except ConversionError as e:
-        assert e.kind == _error.UnsupportedFormatString
-    else:
-        assert False
+    assert e.value.kind == _error.UnsupportedFormatString

--- a/myhdl/test/conversion/general/test_print.py
+++ b/myhdl/test/conversion/general/test_print.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+
+import pytest
+
 import myhdl
 from myhdl import *
 from myhdl import ConversionError
@@ -6,7 +9,9 @@ from myhdl.conversion._misc import _error
 
 t_State = enum("START", "RUN", "STOP")
 
-def PrintBench():
+@pytest.mark.verify_convert
+@block
+def test_print():
     si1 = Signal(intbv(0)[8:])
     si2 = Signal(intbv(0, min=-10, max=12))
     sb = Signal(bool(0))
@@ -66,10 +71,10 @@ def PrintBench():
 
     return logic
 
-def testPrint():
-    assert conversion.verify(PrintBench) == 0
 
-def PrintLongVectorsBench():
+@pytest.mark.verify_convert
+@block
+def test_print_long_vectors():
     N84 = 84
     M84 = 2**N84-1
     N85 = 85
@@ -104,12 +109,6 @@ def PrintLongVectorsBench():
         print("%s %s %s %s" % (i1, i2, si1, si2))
 
     return logic
-
-def testPrintLongVectors():
-    assert conversion.verify(PrintLongVectorsBench) == 0
-
-def testPrint():
-    assert conversion.verify(PrintBench) == 0
 
 # format string errors and unsupported features
 

--- a/myhdl/test/conversion/general/test_ram.py
+++ b/myhdl/test/conversion/general/test_ram.py
@@ -3,6 +3,8 @@ import os
 path = os.path
 import unittest
 
+import pytest
+
 import myhdl
 from myhdl import *
 
@@ -97,6 +99,8 @@ def ram2(dout, din, addr, we, clk, depth=128):
     return wrLogic, rdLogic
 
 
+@pytest.mark.parametrize('ram', [ram_deco1, ram_deco2, ram_clocked, ram2, ram1])
+@pytest.mark.verify_convert
 @block
 def RamBench(ram, depth=128):
 
@@ -134,19 +138,3 @@ def RamBench(ram, depth=128):
             clk.next = not clk
 
     return clkgen, stimulus, mem_inst
-
-
-def testram_deco1():
-    assert conversion.verify(RamBench(ram_deco1)) == 0
-
-def testram_deco2():
-    assert conversion.verify(RamBench(ram_deco2)) == 0
-
-def testram_clocked():
-    assert conversion.verify(RamBench(ram_clocked)) == 0
-    
-def test2():
-    assert conversion.verify(RamBench(ram2)) == 0
-    
-def test1():
-    assert conversion.verify(RamBench(ram1)) == 0

--- a/myhdl/test/conversion/general/test_randscrambler.py
+++ b/myhdl/test/conversion/general/test_randscrambler.py
@@ -9,6 +9,8 @@ from random import randrange
 random.seed(2)
 import time
 
+import pytest
+
 import myhdl
 from myhdl import *
 from myhdl.conversion import verify
@@ -72,8 +74,9 @@ o7, o6, o5, o4, o3, o2, o1, o0 = [Signal(bool()) for i in range(N)]
 i7, i6, i5, i4, i3, i2, i1, i0 = [Signal(bool()) for i in range(N)]
 v7, v6, v5, v4, v3, v2, v1, v0 = [Signal(bool()) for i in range(N)]
 
+@pytest.mark.verify_convert
 @block
-def randscramblerBench():
+def test_randscramber():
 
     @instance
     def stimulus():
@@ -108,6 +111,3 @@ def randscramblerBench():
     )
 
     return rs, stimulus
-
-def test_randscramber():
-    assert conversion.verify(randscramblerBench()) == 0

--- a/myhdl/test/conversion/general/test_rom.py
+++ b/myhdl/test/conversion/general/test_rom.py
@@ -3,6 +3,8 @@ import os
 path = os.path
 from random import randrange
 
+import pytest
+
 import myhdl
 from myhdl import *
 
@@ -58,6 +60,8 @@ def rom4(dout, addr, clk):
     return read
 
       
+@pytest.mark.parametrize('rom', [rom1, rom2, rom3, rom4])
+@pytest.mark.verify_convert
 @block
 def RomBench(rom):
 
@@ -87,20 +91,3 @@ def RomBench(rom):
             clk.next = not clk
 
     return clkgen, stimulus, rom_inst
-
-def test1():
-    assert conversion.verify(RomBench(rom1)) == 0
-    
-def test2():
-    assert conversion.verify(RomBench(rom2)) == 0
-    
-def test3():
-    assert conversion.verify(RomBench(rom3)) == 0
-    
-def test4():
-    assert conversion.verify(RomBench(rom4)) == 0
-
-        
-        
-    
-

--- a/myhdl/test/conversion/general/test_ternary.py
+++ b/myhdl/test/conversion/general/test_ternary.py
@@ -3,6 +3,8 @@ import os
 path = os.path
 import unittest
 
+import pytest
+
 import myhdl
 from myhdl import *
 
@@ -37,6 +39,8 @@ def ternary2(dout, clk, rst):
 
     return logic, comb
 
+@pytest.mark.parametrize('ternary', [ternary1, ternary2])
+@pytest.mark.verify_convert
 @block
 def TernaryBench(ternary):
 
@@ -66,15 +70,3 @@ def TernaryBench(ternary):
         raise StopSimulation()
 
     return stimulus, ternary_inst
-
-
-
-# uncomment when we have a VHDL-2008 compliant simulator
-def test_ternary1():
-    toVHDL.name = 'ternary1'
-    assert conversion.verify(TernaryBench(ternary1)) == 0
-
-def test_ternary2():
-    toVHDL.name = 'ternary2'
-    assert conversion.verify(TernaryBench(ternary2)) == 0
-

--- a/myhdl/test/conversion/general/test_toplevel_method.py
+++ b/myhdl/test/conversion/general/test_toplevel_method.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import sys
+import pytest
 import myhdl
 from myhdl import *
 from myhdl import ConversionError
@@ -124,9 +125,6 @@ def test_hdlobjnotself():
     x = Signal(intbv(0, min=0, max=16))
     y = Signal(intbv(0, min=0, max=16))
     hdlobj_inst = HdlObjNotSelf()
-    try:
+    with pytest.raises(ConversionError) as e:
         hdlobj_inst.method_func(clk, x, srst, y).analyze_convert()
-    except ConversionError as e:
-        assert e.kind == _error.NotSupported
-    else:
-        assert False
+    assert e.value.kind == _error.NotSupported


### PR DESCRIPTION
I'd like to be able to run `pytest` without any arguments and have it run all tests with all simulators I've have installed. Additionally, conversion/simulation tests should use tmpdirs so that the working directory is clean and we can use `pytest-xdist` to parallelize the tests.

- [x] reduce boilerplate code required to run `.verify_convert()` on testbench blocks by introducing a `verify_convert` pytest marker
- [x] use `pytest.mark.parametrize` wherever possible
- [x] use `pytest.raises` for error checking tests
- [ ] create simulation/conversion fixtures which use the tmpdir fixture
- [ ] general cleanup(unused variables, imports)
- [ ] write some documentation about how to use the new markers and fixtures