### PR TITLE
Fix signal trace for array-of-enums

### DIFF
--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -232,7 +232,8 @@ def _writeVcdSigs(f, hierarchy, tracelists):
                         s._code = next(namegen)
                         siglist.append(s)
                     w = s._nrbits
-                    if w:
+                    # use real for enum strings
+                    if w and not isinstance(sval, EnumItemType):
                         if w == 1:
                             print("$var reg 1 %s %s(%i) $end" % (s._code, n, memindex), file=f)
                         else:


### PR DESCRIPTION
This fixes signal trace dumping for arrays of enums.

The problem can be seen if running the code below on current master and inspecting tb.vcd manually / opening it in gtkwave.
gtkwave reports the follow error and stops processing the wavefile: "ERROR: Duplicate IDs with differing width: tb.s_array.s_array(0) tb.s"

```
from myhdl import *

def tb():
  clk = Signal(bool(0))
  @always(delay(5))
  def clock_gen():
    clk.next = not clk

  State = enum("IDLE", "BUSY", "DONE")

  # dumped as:
  # $var reg 2 ! i_array(0) $end
  # $var reg 2 ! i $end
  # matches
  i_array = [Signal(modbv(0)[2:])]
  i = i_array[0]
  
  # dumped as:
  # $var reg 2 " s_array(0) $end
  # $var real 1 " s $end
  # type/bitwidth mismatch!
  s_array = [Signal(State.IDLE)]
  s = s_array[0]

  return clock_gen
  
trace = traceSignals(tb)
sim = Simulation(trace)
sim.run(10)
```