### PR TITLE
Added support for picosecond resolution in VCD trace files.

### DIFF
--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -275,10 +275,10 @@ class _Block(object):
             setattr(converter, k, v)
         return converter(self)
 
-    def config_sim(self, trace=False):
+    def config_sim(self, trace=False, timescale='1ns'):
         self._config_sim['trace'] = trace
         if trace:
-            myhdl.traceSignals(self)
+            myhdl.traceSignals(self, timescale=timescale)
 
     def run_sim(self, duration=None, quiet=0):
         if self.sim is None:

--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -68,6 +68,8 @@ class _TraceSignalsClass(object):
 
     def __call__(self, dut, *args, **kwargs):
         global _tracing, vcdpath
+        if 'timescale' in kwargs:
+            self.timescale = kwargs['timescale']
         if isinstance(dut, _Block):
             # now we go bottom-up: so clean up and start over
             # TODO: consider a warning for the overruled block


### PR DESCRIPTION
- Added optional timescale parameter to _Block.config_sim()
  - Default value is '1ns'
- Forward timescale parameter to traceSignals() call.
- Added code to _traceSignals.py to use optional timescale keyword arg.
- Checked that both '1ns' and '1ps' show up correctly in VCD trace file.