### PR TITLE
Changed backup vcd filename creation

### DIFF
--- a/myhdl/_traceSignals.py
+++ b/myhdl/_traceSignals.py
@@ -122,7 +122,7 @@ class _TraceSignalsClass(object):
             vcdpath = os.path.join(directory, filename + ".vcd")
 
             if path.exists(vcdpath):
-                backup = vcdpath + '.' + str(path.getmtime(vcdpath))
+                backup = vcdpath[:-4] + '.' + str(path.getmtime(vcdpath)) + '.vcd'
                 shutil.copyfile(vcdpath, backup)
                 os.remove(vcdpath)
             vcdfile = open(vcdpath, 'w')

--- a/myhdl/test/core/test_traceSignals.py
+++ b/myhdl/test/core/test_traceSignals.py
@@ -173,7 +173,7 @@ class TestTraceSigs:
         _simulator._tf.close()
         _simulator._tracing = 0
         size = path.getsize(p)
-        pbak = p + '.' + str(path.getmtime(p))
+        pbak = p[:-4] + '.' + str(path.getmtime(p)) + '.vcd'
         assert not path.exists(pbak)
         dut = traceSignals(fun())
         _simulator._tf.close()


### PR DESCRIPTION
When there is already a vcd file with the same name, do not just append the timestamp to the filename, but remove the '.vcd' extension, append the timestamp and append the .vcd extension again, so that file will always have the right file extension (very useful for windows systems)