### PR TITLE
Fixed a typo in the VHDL conversion of concat

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1086,7 +1086,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             return
         elif f is concat:
             pre, suf = self.inferCast(node.vhd, node.vhdOri)
-            opening, closing = "unsigned'(", ")"
+            opening, closing = "unsigned(", ")"
             sep = " & "
         elif hasattr(node, 'tree'):
             pre, suf = self.inferCast(node.vhd, node.tree.vhd)


### PR DESCRIPTION
The signals should be wrapped inside an unsigned() instead of an unsigned'().