### PR TITLE
VHDL convertion : Remove unsigned() cast

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1502,9 +1502,9 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             self.write(post)
             return
         pre, suf = self.inferCast(node.vhd, node.vhdOri)
-        if isinstance(node.value.vhd, vhd_signed) and isinstance(node.ctx, ast.Load):
-            pre = pre + "unsigned("
-            suf = ")" + suf
+#        if isinstance(node.value.vhd, vhd_signed) and isinstance(node.ctx, ast.Load):
+#            pre = pre + "unsigned("
+#            suf = ")" + suf
         self.write(pre)
         self.visit(node.value)
         lower, upper = node.slice.lower, node.slice.upper


### PR DESCRIPTION
Remove unsigned cast for signed values when converting to VHDL.

I need this patch in my designs since I use signed intbv() a lot.
Without this patch, my designs don't work.
