### PR TITLE
Reports range() without argument correctly

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1208,6 +1208,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         args = cf.args
         assert len(args) <= 3
         self.require(node, len(args) < 3, "explicit step not supported")
+        self.require(node, len(args) > 0, "at least one argument requested")
         if f is range:
             cmp = '<'
             op = 'to'


### PR DESCRIPTION
When using range() without parameter, a cryptic error message is displayed by converter :
```
File "C:\Python34\lib\site-packages\myhdl-1.0.dev0-py3.4.egg\myhdl\conversion\_toVHDL.py", line 1275, in visit_For
    start, stop, step = args
ValueError: need more than 0 values to unpack
```

Replaces it by a useful information message :
```
myhdl.ConversionError: in file xxx.py, line 49:
    Requirement violation: at least one argument requested
```