### PR TITLE
A fix for initial value memory conversion and user code

### DIFF
--- a/myhdl/_extractHierarchy.py
+++ b/myhdl/_extractHierarchy.py
@@ -115,7 +115,14 @@ class _UserCode(object):
         code = "\n%s\n" % code
         return code
 
+    def _scrub_namespace(self):
+        for nm, obj in self.namespace.items():
+            if _isMem(obj):
+                memi = _getMemInfo(obj)
+                self.namespace[nm] = memi.name
+
     def _interpolate(self):
+        self._scrub_namespace()
         return string.Template(self.code).substitute(self.namespace)
 
 


### PR DESCRIPTION
If a list-of-signals is referenced in user defined code,
the conversion fails.

The string of the list-of-signals (LOS) was written instead
of the name of the reference to the LOS.  A function was
added to resolve the name instead of the raw string
conversion of the type.