### PR TITLE
intbv.unsigned() internal enhancement

### DIFF
--- a/myhdl/_intbv.py
+++ b/myhdl/_intbv.py
@@ -554,18 +554,8 @@ class intbv(object):
 
         # value is considered unsigned
         if self.min is not None and self.min < 0 and self._nrbits:
-
-            # get 2's complement value of bits
-            msb = self._nrbits - 1
-
-            sign = ((self._val >> msb) & 0x1) > 0
-
-            # mask off the bits msb-1:lsb, they are always positive
-            mask = (1 << msb) - 1
+            mask = (1 << self._nrbits) - 1
             retVal = self._val & mask
-            # if sign bit is set, subtract the value of the sign bit
-            if sign:
-                retVal -= 1 << msb
 
         else:  # value is returned just as is
             retVal = self._val


### PR DESCRIPTION
While the current unsigned() method of intbv() class gives correct results, its internal coding is not optimal.
This is a patch to make internal code more efficient and more "conceptually correct".