### PR TITLE
fixes signal assigment with .min .max and len()

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -916,7 +916,10 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
                 self.write(suf)
         if isinstance(obj, (_Signal, intbv)):
             if node.attr in ('min', 'max'):
+                pre, suf = self.inferCast(node.vhd, node.vhdOri)
+                self.write(pre)
                 self.write("%s" % node.obj)
+                self.write(suf)
         if isinstance(obj, EnumType):
             assert hasattr(obj, node.attr)
             e = getattr(obj, node.attr)
@@ -1040,7 +1043,10 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         elif f is len:
             val = self.getVal(node)
             self.require(node, val is not None, "cannot calculate len")
+            pre, suf = self.inferCast(node.vhd, node.vhdOri)
+            self.write(pre)
             self.write(repr(val))
+            self.write(suf)
             return
         elif f is now:
             pre, suf = self.inferCast(node.vhd, node.vhdOri)


### PR DESCRIPTION
Consider the following code :
```python
@block
def test(i_Clk, i_Sample, o_Sample):
    @always_seq(i_Clk.posedge, reset=None)
    def compute_proc() :
        o_Sample.next = i_Sample.min
        o_Sample.next = i_Sample.max
        o_Sample.next = len(i_Sample)
    return compute_proc

def ConvertTest():
    i_Clk    = Signal(bool(0))
    i_Sample = Signal(intbv(0)[24:])
    o_Sample = Signal(intbv(0)[30:])
    dut = test(i_Clk, i_Sample, o_Sample)
    dut.convert(hdl='VHDL', name="test", path=".", initial_values=True)

ConvertTest()
```
The following statements :
```python
        o_Sample.next = i_Sample.min
        o_Sample.next = i_Sample.max
        o_Sample.next = len(i_Sample)
```
convert to :
```vhdl
        o_Sample <= 0
        o_Sample <= 16777216
        o_Sample <= 24
```
while they should convert to :
```vhdl
        o_Sample <= to_unsigned(0, 30);
        o_Sample <= to_unsigned(16777216, 30);
        o_Sample <= to_unsigned(24, 30);
```

This patch fixes this issue.
