### PR TITLE
EnumType is allowed as free variables

### DIFF
--- a/myhdl/conversion/_analyze.py
+++ b/myhdl/conversion/_analyze.py
@@ -626,7 +626,7 @@ class _AnalyzeVisitor(ast.NodeVisitor, _ConversionMixin):
             if f.__code__.co_freevars:
                 for n, c in zip(f.__code__.co_freevars, f.__closure__):
                     obj = c.cell_contents
-                    if not isinstance(obj, (integer_types, _Signal)):
+                    if not isinstance(obj, (integer_types, _Signal, EnumType)):
                         self.raiseError(node, _error.FreeVarTypeError, n)
                     tree.symdict[n] = obj
             v = _FirstPassVisitor(tree)


### PR DESCRIPTION
EnumType is integer-like, and should be allowed where integer is allowed, I think.