### PR TITLE
Renamed async variables to remove namespace conflict with new keyword introduced in Python V3.5

### DIFF
--- a/myhdl/_always_seq.py
+++ b/myhdl/_always_seq.py
@@ -45,7 +45,7 @@ _error.EmbeddedFunction = "embedded functions in always_seq function not support
 
 class ResetSignal(_Signal):
 
-    def __init__(self, val, active, async):
+    def __init__(self, val, active, isAsync):
         """ Construct a ResetSignal.
 
         This is to be used in conjunction with the always_seq decorator,
@@ -53,7 +53,7 @@ class ResetSignal(_Signal):
         """
         _Signal.__init__(self, bool(val))
         self.active = bool(active)
-        self.async = async
+        self.isAsync = isAsync
 
 
 def always_seq(edge, reset):
@@ -91,8 +91,8 @@ class _AlwaysSeq(_Always):
         if reset is not None:
             self.genfunc = self.genfunc_reset
             active = self.reset.active
-            async = self.reset.async
-            if async:
+            isAsync = self.reset.isAsync
+            if isAsync:
                 if active:
                     senslist.append(reset.posedge)
                 else:

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1838,12 +1838,12 @@ class _ConvertAlwaysSeqVisitor(_ConvertVisitor):
         senslist = self.tree.senslist
         edge = senslist[0]
         reset = self.tree.reset
-        async = reset is not None and reset.async
+        isAsync = reset is not None and reset.isAsync
         sigregs = self.tree.sigregs
         varregs = self.tree.varregs
         self.write("%s: process (" % self.tree.name)
         self.write(edge.sig)
-        if async:
+        if isAsync:
             self.write(', ')
             self.write(reset)
         self.write(") is")
@@ -1853,7 +1853,7 @@ class _ConvertAlwaysSeqVisitor(_ConvertVisitor):
         self.writeline()
         self.write("begin")
         self.indent()
-        if not async:
+        if not isAsync:
             self.writeline()
             self.write("if %s then" % edge._toVHDL())
             self.indent()
@@ -1870,7 +1870,7 @@ class _ConvertAlwaysSeqVisitor(_ConvertVisitor):
                 self.write("%s := %s;" % (n, _convertInitVal(reg, init)))
             self.dedent()
             self.writeline()
-            if async:
+            if isAsync:
                 self.write("elsif %s then" % edge._toVHDL())
             else:
                 self.write("else")
@@ -1881,7 +1881,7 @@ class _ConvertAlwaysSeqVisitor(_ConvertVisitor):
             self.writeline()
             self.write("end if;")
             self.dedent()
-        if not async:
+        if not isAsync:
             self.writeline()
             self.write("end if;")
             self.dedent()


### PR DESCRIPTION
In and from Python V3.5, the keyword "async" was introduced to make asynchronous programming a fully first-class element of the language.

This caused a name conflict with similarly-named member variables in the MyHdl module, so those have been replaced with the non-conflicting "isAsync".

The MyHdl module now loads without error in Python V3.7.