### PR TITLE
Rename async to isasync to resolve conflict with python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,8 @@ env:
   - CI_TARGET=iverilog
   - CI_TARGET=ghdl
 
-# Remove when py37 bugs are fixed
 matrix:
   allow_failures:
-    - python: "3.7"
     - python: "pypy3.5"
 
 

--- a/doc/source/manual/reference.rst
+++ b/doc/source/manual/reference.rst
@@ -276,13 +276,13 @@ Regular signals
 	This method returns a :class:`_SliceSignal` shadow signal. 
 
 
-.. class:: ResetSignal(val, active, async)
+.. class:: ResetSignal(val, active, isasync)
 
-    This Signal subclass defines reset signals. *val*, *active*, and *async*
+    This Signal subclass defines reset signals. *val*, *active*, and *isasync*
     are mandatory arguments.
     *val* is a boolean value that specifies the intial value,
     *active* is a boolean value that specifies the active level.
-    *async* is a boolean value that specifies the reset style:
+    *isasync* is a boolean value that specifies the reset style:
     asynchronous (``True``) or synchronous (``False``).
 
     This class should be used in conjunction with the :func:`always_seq`

--- a/doc/source/manual/rtl.rst
+++ b/doc/source/manual/rtl.rst
@@ -107,10 +107,10 @@ functionality.  It detects which signals need to be reset, and uses their
 initial values as the reset values. The reset signal itself needs to be
 specified as a :class:`ResetSignal` object. For example::
 
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
 
 The first parameter specifies the initial value. The *active* parameter
-specifies the value on which the reset is active, and the *async*
+specifies the value on which the reset is active, and the *isasync*
 parameter specifies whether it is an asychronous (``True``) or a
 synchronous (``False``) reset. If no reset is needed, you can assign
 ``None`` to the *reset* parameter in the :func:`always_seq` parameter.

--- a/example/manual/GrayInc.py
+++ b/example/manual/GrayInc.py
@@ -32,7 +32,7 @@ def main():
     graycnt = Signal(modbv(0)[width:])
     enable = Signal(bool())
     clock = Signal(bool())
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
 
     toVerilog(GrayIncReg, graycnt, enable, clock, reset, width)
     toVHDL(GrayIncReg, graycnt, enable, clock, reset, width)

--- a/example/manual/conv_inc.py
+++ b/example/manual/conv_inc.py
@@ -10,7 +10,7 @@ m = 8
 count = Signal(modbv(0)[m:])
 enable = Signal(bool(0))
 clock  = Signal(bool(0))
-reset = ResetSignal(0, active=0, async=True)
+reset = ResetSignal(0, active=0, isasync=True)
 
 inc_inst = inc(count, enable, clock, reset)
 inc_inst = toVerilog(inc, count, enable, clock, reset)

--- a/example/manual/convert_gray_inc_reg.py
+++ b/example/manual/convert_gray_inc_reg.py
@@ -6,7 +6,7 @@ def convert_gray_inc_reg(hdl, width=8):
     graycnt = Signal(modbv(0)[width:])
     enable = Signal(bool())
     clock = Signal(bool())
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
 
     inst = gray_inc_reg(graycnt, enable, clock, reset, width)
     inst.convert(hdl)

--- a/example/manual/convert_inc.py
+++ b/example/manual/convert_inc.py
@@ -10,7 +10,7 @@ def convert_inc(hdl):
     count = Signal(modbv(0)[m:])
     enable = Signal(bool(0))
     clock  = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
 
     inc_1 = inc(count, enable, clock, reset)
 

--- a/example/manual/test_fsm.py
+++ b/example/manual/test_fsm.py
@@ -10,7 +10,7 @@ def testbench():
     sof = Signal(bool(0))
     sync_flag = Signal(bool(0))
     clk = Signal(bool(0))
-    reset_n = ResetSignal(1, active=ACTIVE_LOW, async=True)
+    reset_n = ResetSignal(1, active=ACTIVE_LOW, isasync=True)
     state = Signal(t_state.SEARCH)
 
     frame_ctrl_0 = framer_ctrl(sof, state, sync_flag, clk, reset_n)

--- a/example/manual/test_inc.py
+++ b/example/manual/test_inc.py
@@ -14,7 +14,7 @@ def testbench():
     count = Signal(modbv(0)[m:])
     enable = Signal(bool(0))
     clock  = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
 
     inc_1 = inc(count, enable, clock, reset)
 

--- a/example/uart_tx/uart_tx.py
+++ b/example/uart_tx/uart_tx.py
@@ -65,7 +65,7 @@ def tb(uart_tx):
     tx_byte = Signal(intbv(0)[8:])
     tx_clk = Signal(bool(0))
     # tx_rst = Signal(bool(1))
-    tx_rst = ResetSignal(1, active=0, async=True)
+    tx_rst = ResetSignal(1, active=0, isasync=True)
    
     uart_tx_inst = uart_tx(tx_bit, tx_valid, tx_byte, tx_clk, tx_rst)
     

--- a/myhdl/_always_seq.py
+++ b/myhdl/_always_seq.py
@@ -45,7 +45,7 @@ _error.EmbeddedFunction = "embedded functions in always_seq function not support
 
 class ResetSignal(_Signal):
 
-    def __init__(self, val, active, async):
+    def __init__(self, val, active, isasync):
         """ Construct a ResetSignal.
 
         This is to be used in conjunction with the always_seq decorator,
@@ -53,7 +53,7 @@ class ResetSignal(_Signal):
         """
         _Signal.__init__(self, bool(val))
         self.active = bool(active)
-        self.async = async
+        self.isasync = isasync
 
 
 def always_seq(edge, reset):
@@ -91,8 +91,8 @@ class _AlwaysSeq(_Always):
         if reset is not None:
             self.genfunc = self.genfunc_reset
             active = self.reset.active
-            async = self.reset.async
-            if async:
+            isasync = self.reset.isasync
+            if isasync:
                 if active:
                     senslist.append(reset.posedge)
                 else:

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1838,12 +1838,12 @@ class _ConvertAlwaysSeqVisitor(_ConvertVisitor):
         senslist = self.tree.senslist
         edge = senslist[0]
         reset = self.tree.reset
-        async = reset is not None and reset.async
+        isasync = reset is not None and reset.isasync
         sigregs = self.tree.sigregs
         varregs = self.tree.varregs
         self.write("%s: process (" % self.tree.name)
         self.write(edge.sig)
-        if async:
+        if isasync:
             self.write(', ')
             self.write(reset)
         self.write(") is")
@@ -1853,7 +1853,7 @@ class _ConvertAlwaysSeqVisitor(_ConvertVisitor):
         self.writeline()
         self.write("begin")
         self.indent()
-        if not async:
+        if not isasync:
             self.writeline()
             self.write("if %s then" % edge._toVHDL())
             self.indent()
@@ -1870,7 +1870,7 @@ class _ConvertAlwaysSeqVisitor(_ConvertVisitor):
                 self.write("%s := %s;" % (n, _convertInitVal(reg, init)))
             self.dedent()
             self.writeline()
-            if async:
+            if isasync:
                 self.write("elsif %s then" % edge._toVHDL())
             else:
                 self.write("else")
@@ -1881,7 +1881,7 @@ class _ConvertAlwaysSeqVisitor(_ConvertVisitor):
             self.writeline()
             self.write("end if;")
             self.dedent()
-        if not async:
+        if not isasync:
             self.writeline()
             self.write("end if;")
             self.dedent()

--- a/myhdl/test/bugs/test_bug_boolop.py
+++ b/myhdl/test/bugs/test_bug_boolop.py
@@ -28,7 +28,7 @@ def gray_counter (clk, reset, enable, gray_count):
     return comb, seq
        
 clk = Signal(bool(0))
-reset = ResetSignal(0, active=0, async=True)
+reset = ResetSignal(0, active=0, isasync=True)
 enable = Signal(bool(0))
 gray_count = Signal(intbv(0)[8:])
 

--- a/myhdl/test/bugs/test_issue_13.py
+++ b/myhdl/test/bugs/test_issue_13.py
@@ -31,7 +31,7 @@ def issue_13(reset, clk, d, en, q):
 
 def test_issue_13():
 
-    reset = ResetSignal(0, active=1, async=False)
+    reset = ResetSignal(0, active=1, isasync=False)
     clk   = Signal(bool(0))
     d     = Signal(intbv(0)[32:])
     en    = Signal(bool(0))

--- a/myhdl/test/bugs/test_issue_185.py
+++ b/myhdl/test/bugs/test_issue_185.py
@@ -16,7 +16,7 @@ def shifter(reset, clock, opa, opb, result):
 def convert():
 
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=True, async=True)
+    reset = ResetSignal(0, active=True, isasync=True)
 
     opa = Signal(intbv(0)[4:])
     opb = Signal(intbv(0)[4:])

--- a/myhdl/test/bugs/test_issue_40.py
+++ b/myhdl/test/bugs/test_issue_40.py
@@ -26,7 +26,7 @@ def mpegChannel(clk, rst):
 
 def test_issue_40():
     clk = Signal(bool(0))
-    rst = ResetSignal(0, active=1, async=True)
+    rst = ResetSignal(0, active=1, isasync=True)
 
     assert conversion.analyze(mpegChannel, clk, rst) == 0
 

--- a/myhdl/test/conversion/general/test_initial_values.py
+++ b/myhdl/test/conversion/general/test_initial_values.py
@@ -308,7 +308,7 @@ def initial_value_list_bench(initial_vals, **kwargs):
 def initial_value_mem_convert_bench():
 
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     wr = Signal(bool(0))
     wrd = Signal(intbv(0, min=0, max=32))
     rdd = Signal(intbv(0, min=0, max=32))

--- a/myhdl/test/conversion/general/test_interfaces1.py
+++ b/myhdl/test/conversion/general/test_interfaces1.py
@@ -38,7 +38,7 @@ def two_level(clock, reset, ia, ib):
 @block
 def c_testbench_one():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     ia, ib = MyIntf(), MyIntf()
 
     tb_dut = one_level(clock, reset, ia, ib)
@@ -70,7 +70,7 @@ def c_testbench_one():
 @block
 def c_testbench_two():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     ia, ib = MyIntf(), MyIntf()
 
     tb_dut = two_level(clock, reset, ia, ib)
@@ -101,7 +101,7 @@ def c_testbench_two():
 
 def test_one_level_analyze():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     ia, ib = MyIntf(), MyIntf()
     inst = one_level(clock, reset, ia, ib)
     assert inst.analyze_convert() == 0
@@ -114,7 +114,7 @@ def test_one_level_verify():
 
 def test_two_level_analyze():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     ia, ib = MyIntf(), MyIntf()
     inst = two_level(clock, reset, ia, ib)
     assert inst.analyze_convert() == 0

--- a/myhdl/test/conversion/general/test_interfaces2.py
+++ b/myhdl/test/conversion/general/test_interfaces2.py
@@ -75,7 +75,7 @@ def name_conflict_after_replace(clock, reset, a, a_x):
 
 def test_name_conflict_after_replace():
     clock = Signal(False)
-    reset = ResetSignal(0, active=0, async=False)
+    reset = ResetSignal(0, active=0, isasync=False)
     a = Intf()
     a_x = Signal(intbv(0)[len(a.x):])
     inst = name_conflict_after_replace(clock, reset, a, a_x)
@@ -85,7 +85,7 @@ def test_name_conflict_after_replace():
 @block
 def c_testbench():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=False)
+    reset = ResetSignal(0, active=0, isasync=False)
     a, b, c = Intf(), Intf(), Intf()
 
     tb_dut = use_interfaces(clock, reset, a, b, c)
@@ -117,7 +117,7 @@ def c_testbench():
 
 def test_name_conflicts_analyze():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=False)
+    reset = ResetSignal(0, active=0, isasync=False)
     a, b, c = Intf(), Intf(), Intf()
     inst = use_interfaces(clock, reset, a, b, c)
     assert inst.analyze_convert() == 0

--- a/myhdl/test/conversion/general/test_interfaces3.py
+++ b/myhdl/test/conversion/general/test_interfaces3.py
@@ -151,7 +151,7 @@ def c_testbench_three():
     as well as top-level interface conversion.
     """
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     x = Signal(intbv(3, min=-5000, max=5000))
     y = Signal(intbv(4, min=-200, max=200))
     intf = IntfWithConstant2()
@@ -217,7 +217,7 @@ def test_two_verify():
 
 def test_three_analyze():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     x = Signal(intbv(3, min=-5000, max=5000))
     y = Signal(intbv(4, min=-200, max=200))
     intf = IntfWithConstant2()

--- a/myhdl/test/conversion/general/test_interfaces4.py
+++ b/myhdl/test/conversion/general/test_interfaces4.py
@@ -98,7 +98,7 @@ def c_testbench_one():
     used in this example caused and invalid multiple driver error.
     """
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=1, async=False)
+    reset = ResetSignal(0, active=1, isasync=False)
     sdi = Signal(bool(0))
     sdo = Signal(bool(0))
     nested = Signal(bool())
@@ -145,7 +145,7 @@ def test_one_testbench():
 
 def test_one_analyze():
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=1, async=False)
+    reset = ResetSignal(0, active=1, isasync=False)
     sdi = Signal(bool(0))
     sdo = Signal(bool(0))
     nested = Signal(bool(0))

--- a/myhdl/test/conversion/general/test_nonlocal.py
+++ b/myhdl/test/conversion/general/test_nonlocal.py
@@ -14,7 +14,7 @@ def NonlocalBench():
     qout = Signal(intbv(ONE)[8:])
     init = Signal(bool(0))
     clk = Signal(bool(0))
-    reset = ResetSignal(0, active=1, async=True)
+    reset = ResetSignal(0, active=1, isasync=True)
 
     q = intbv(ONE)[8:]
 

--- a/myhdl/test/core/test_always_seq.py
+++ b/myhdl/test/core/test_always_seq.py
@@ -10,7 +10,7 @@ def test_clock():
 
     # should fail without a valid Signal
     clock = Signal(bool(0))
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
 
     with raises_kind(AlwaysSeqError, _error.EdgeType):
         @always_seq(clock, reset=reset)
@@ -40,7 +40,7 @@ def test_reset():
             pass
 
     # should work with a valid Signal
-    reset = ResetSignal(0, active=0, async=True)
+    reset = ResetSignal(0, active=0, isasync=True)
     try:
         @always_seq(clock.posedge, reset=reset)
         def logic2():


### PR DESCRIPTION
Python 3.7 makes 'async' a syntax error.  This renames all instances of 'async' to 'isasync' to fix this issue.  