### PR TITLE
Added VHDL Keyword check for 'enum' member names

### DIFF
--- a/myhdl/_Simulation.py
+++ b/myhdl/_Simulation.py
@@ -21,14 +21,13 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-
 import os
 from operator import itemgetter
-from warnings import warn
 from types import GeneratorType
 
-from myhdl import Cosimulation, StopSimulation, _SuspendSimulation
+from myhdl import StopSimulation, _SuspendSimulation
 from myhdl import _simulator, SimulationError
+from myhdl._Cosimulation import Cosimulation
 from myhdl._simulator import _signals, _siglist, _futureEvents
 from myhdl._Waiter import _Waiter
 from myhdl._Waiter import _inferWaiter
@@ -42,6 +41,8 @@ schedule = _futureEvents.append
 
 class _error:
     pass
+
+
 _error.ArgType = "Inappriopriate argument type"
 _error.MultipleCosim = "Only a single cosimulator argument allowed"
 _error.DuplicatedArg = "Duplicated argument"
@@ -60,6 +61,7 @@ def _flatten(*args):
         else:
             arglist.append(arg)
     return arglist
+
 
 _error.MultipleSim = "Only a single Simulation instance is allowed"
 

--- a/myhdl/_enum.py
+++ b/myhdl/_enum.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 from myhdl._bin import bin
 from myhdl._Signal import _Signal
 from myhdl._compat import string_types
-# from myhdl.conversion._VHDLNameValidation import _nameValid
+from myhdl.conversion._VHDLNameValidation import _nameValid
 
 
 class EnumType(object):
@@ -165,11 +165,16 @@ def enum(*names, **kwargs):
         _toVHDL = __str__
 
         def _toVHDL(self):
-#             # check if a member name conflicts with a reserved VHDL keyword
-#             for name in self.names:
-#                 _nameValid(name)
-
             typename = self.__dict__['_name']
+            # check if a member name conflicts with a reserved VHDL keyword
+            for name in self.names:
+                # watch out _nameValid() will add every name to a check-list
+                # which will force you to be inventive with state names ...
+                # e.g. the typical 'IDLE' can only be used once
+                # so let's pre-fix the enum name
+                # we could have modified _nameValid() to take a default boolean argument
+                _nameValid(''.join((typename, '.', name)))
+
             enumtypedecl = "type %s is (\n    " % typename
             enumtypedecl += ",\n    ".join(self._names)
             enumtypedecl += "\n);"

--- a/myhdl/_enum.py
+++ b/myhdl/_enum.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 from myhdl._bin import bin
 from myhdl._Signal import _Signal
 from myhdl._compat import string_types
-from myhdl.conversion._VHDLNameValidation import _nameValid
+# from myhdl.conversion._VHDLNameValidation import _nameValid
 
 
 class EnumType(object):
@@ -165,9 +165,9 @@ def enum(*names, **kwargs):
         _toVHDL = __str__
 
         def _toVHDL(self):
-            # check if a member name conflicts with a reserved VHDL keyword
-            for name in self.names:
-                _nameValid(name)
+#             # check if a member name conflicts with a reserved VHDL keyword
+#             for name in self.names:
+#                 _nameValid(name)
 
             typename = self.__dict__['_name']
             enumtypedecl = "type %s is (\n    " % typename

--- a/myhdl/_enum.py
+++ b/myhdl/_enum.py
@@ -168,7 +168,7 @@ def enum(*names, **kwargs):
             typename = "t_enum_%s" % name
             self.__dict__['_name'] = typename
 
-        _toVHDL = __str__
+#         _toVHDL = __str__
 
 #         def _toVHDL(self):
 #             typename = self.__dict__['_name']

--- a/myhdl/_enum.py
+++ b/myhdl/_enum.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import
 from myhdl._bin import bin
 from myhdl._Signal import _Signal
 from myhdl._compat import string_types
-from myhdl.conversion._VHDLNameValidation import _nameValid
+# from myhdl.conversion._VHDLNameValidation import _nameValid
 
 
 class EnumType(object):
@@ -87,9 +87,12 @@ def enum(*names, **kwargs):
             return hash((self._type, self._index))
 
         def __repr__(self):
-            return self._name
+            return "'{}'".format(self._name)
 
-        __str__ = __repr__
+#         __str__ = __repr__
+
+        def __str__(self):
+            return self._name
 
         def __int__(self):
             return int(self._val, 2)
@@ -154,9 +157,12 @@ def enum(*names, **kwargs):
             return len(self._names)
 
         def __repr__(self):
-            return "<Enum: %s>" % ", ".join(names)
+            return 'enum({})'.format(",".join(["'{}'".format(n) for n in  self._names]))
 
-        __str__ = __repr__
+#         __str__ = __repr__
+
+        def __str__(self):
+            return "<Enum: %s>" % ", ".join(self._names)
 
         def _setName(self, name):
             typename = "t_enum_%s" % name
@@ -164,23 +170,30 @@ def enum(*names, **kwargs):
 
         _toVHDL = __str__
 
-        def _toVHDL(self):
-            typename = self.__dict__['_name']
-            # check if a member name conflicts with a reserved VHDL keyword
-            for name in self.names:
-                # watch out _nameValid() will add every name to a check-list
-                # which will force you to be inventive with state names ...
-                # e.g. the typical 'IDLE' can only be used once
-                # so let's pre-fix the enum name
-                # we could have modified _nameValid() to take a default boolean argument
-                _nameValid(''.join((typename, '.', name)))
+#         def _toVHDL(self):
+#             typename = self.__dict__['_name']
+#             # check if a member name conflicts with a reserved VHDL keyword
+# #             for name in self.names:
+# #                 # watch out _nameValid() will add every name to a check-list
+# #                 # which will force you to be inventive with state names ...
+# #                 # e.g. the typical 'IDLE' can only be used once
+# #                 # so let's pre-fix the enum name
+# #                 # we could have modified _nameValid() to take a default boolean argument
+# #                 _nameValid(''.join((typename, '.', name)))
+#
+#             enumtypedecl = "type %s is (\n    " % typename
+#             enumtypedecl += ",\n    ".join(self._names)
+#             enumtypedecl += "\n);"
+#             if self._encoding is not None:
+#                 codes = " ".join([self._codedict[name] for name in self._names])
+#                 enumtypedecl += '\nattribute enum_encoding of %s: type is "%s";' % (typename, codes)
+#             return enumtypedecl
 
-            enumtypedecl = "type %s is (\n    " % typename
-            enumtypedecl += ",\n    ".join(self._names)
-            enumtypedecl += "\n);"
+        def reftype(self):
+            typename = self.__dict__['_name']
+            codes = None
             if self._encoding is not None:
                 codes = " ".join([self._codedict[name] for name in self._names])
-                enumtypedecl += '\nattribute enum_encoding of %s: type is "%s";' % (typename, codes)
-            return enumtypedecl
+            return (typename, (self._names) , codes)
 
     return Enum(names, codedict, nrbits, encoding)

--- a/myhdl/conversion/_VHDLNameValidation.py
+++ b/myhdl/conversion/_VHDLNameValidation.py
@@ -1,5 +1,5 @@
 import warnings
-from myhdl import *
+# from myhdl import *
 from myhdl import ToVHDLWarning
 
 # A list of all reserved words within VHDL which should not be used for

--- a/myhdl/conversion/_VHDLNameValidation.py
+++ b/myhdl/conversion/_VHDLNameValidation.py
@@ -1,6 +1,6 @@
 import warnings
 # from myhdl import *
-from myhdl import ToVHDLWarning
+# from myhdl import ToVHDLWarning
 
 # A list of all reserved words within VHDL which should not be used for
 # anything other than their own specific purpose
@@ -33,16 +33,16 @@ _usedNames = [];
 # ensure reserved words are not being used for the wrong purpose
 def _nameValid(name):
     if name.lower() in _vhdl_keywords:
-        warnings.warn("VHDL keyword used: %s" % (name), category=ToVHDLWarning)
+        warnings.warn("VHDL keyword used: %s" % (name))
 
     if name.startswith('_'):
-        warnings.warn("VHDL variable names cannot start with '_': %s" % (name), category=ToVHDLWarning)
+        warnings.warn("VHDL variable names cannot start with '_': %s" % (name))
 
     if '-' in name:
-        warnings.warn("VHDL variable names cannot contain '-': %s" % (name), category=ToVHDLWarning)
+        warnings.warn("VHDL variable names cannot contain '-': %s" % (name))
 
     if name.lower() in _usedNames:
-        warnings.warn("Previously used name being reused: %s" % (name), category=ToVHDLWarning)
+        warnings.warn("Previously used name being reused: %s" % (name))
 
     _usedNames.append(name.lower())
 

--- a/myhdl/conversion/_VHDLNameValidation.py
+++ b/myhdl/conversion/_VHDLNameValidation.py
@@ -2,44 +2,47 @@ import warnings
 from myhdl import *
 from myhdl import ToVHDLWarning
 
-#A list of all reserved words within VHDL which should not be used for
-#anything other than their own specific purpose
+# A list of all reserved words within VHDL which should not be used for
+# anything other than their own specific purpose
 _vhdl_keywords = ["abs", "access", "after", "alias", "all",
-              "and", "architecture", "array", "assert",
-              "attribute", "begin", "block", "body", "buffer",
-              "bus", "case", "component", "configuration",
-              "constant", "disconnect", "downto", "else",
-              "elseif", "end", "entity", "exit", "file", "for",
-              "function", "generate", "generic", "group",
-              "guarded", "if", "impure", "in", "inertial",
-              "inout", "is", "label", "library", "linkage",
-              "literal", "loop", "map", "mod", "nand", "new",
-              "next", "nor", "not", "null", "of", "on", "open",
-              "or", "others", "out", "package", "port",
-              "postponed", "procedure", "process", "pure",
-              "range", "record", "register", "reject", "rem",
-              "report", "return", "rol", "ror", "select",
-              "severity", "signal", "shared", "sla", "sll", "sra",
-              "srl", "subtype", "then", "to", "transport", "type",
-              "unaffected", "units", "until", "use", "variable",
-              "wait", "when", "while", "with", "xnor", "xor"];
+                  "and", "architecture", "array", "assert",
+                  "attribute", "begin", "block", "body", "buffer",
+                  "bus", "case", "component", "configuration",
+                  "constant", "disconnect", "downto", "else",
+                  "elseif", "end", "entity", "exit", "file", "for",
+                  "function", "generate", "generic", "group",
+                  "guarded", "if", "impure", "in", "inertial",
+                  "inout", "is", "label", "library", "linkage",
+                  "literal", "loop", "map", "mod", "nand", "new",
+                  "next", "nor", "not", "null", "of", "on", "open",
+                  "or", "others", "out", "package", "port",
+                  "postponed", "procedure", "process", "pure",
+                  "range", "record", "register", "reject", "rem",
+                  "report", "return", "rol", "ror", "select",
+                  "severity", "signal", "shared", "sla", "sll", "sra",
+                  "srl", "subtype", "then", "to", "transport", "type",
+                  "unaffected", "units", "until", "use", "variable",
+                  "wait", "when", "while", "with", "xnor", "xor"];
 
-#A list to hold all signal names being used in lowercase to raise an error
-#if no names are reused with different casing
+# A list to hold all signal names being used in lowercase to raise an error
+# if no names are reused with different casing
 _usedNames = [];
 
-#Function which compares current parsed signal/entity to all keywords to
-#ensure reserved words are not being used for the wrong purpose
+
+# Function which compares current parsed signal/entity to all keywords to
+# ensure reserved words are not being used for the wrong purpose
 def _nameValid(name):
-    for keyword in _vhdl_keywords:
-        if name == keyword:
-            warnings.warn("VHDL keyword used: %s" % (name), category=ToVHDLWarning)
-    for saved_name in _usedNames:
-        if name.lower() == saved_name:
-            warnings.warn("Previously used name being reused: %s" % (name), category=ToVHDLWarning)
+    if name.lower() in _vhdl_keywords:
+        warnings.warn("VHDL keyword used: %s" % (name), category=ToVHDLWarning)
+
+    if name.startswith('_'):
+        warnings.warn("VHDL variable names cannot start with '_': %s" % (name), category=ToVHDLWarning)
+
+    if '-' in name:
+        warnings.warn("VHDL variable names cannot contain '-': %s" % (name), category=ToVHDLWarning)
+
+    if name.lower() in _usedNames:
+        warnings.warn("Previously used name being reused: %s" % (name), category=ToVHDLWarning)
+
     _usedNames.append(name.lower())
-    if name[0] == '_':
-        warnings.warn("VHDL variable names cannot contain '_': %s" % (name), category=ToVHDLWarning)
-    for char in name:
-        if char == '-':
-            warnings.warn("VHDL variable names cannot contain '-': %s" % (name), category=ToVHDLWarning)
+

--- a/myhdl/conversion/__init__.py
+++ b/myhdl/conversion/__init__.py
@@ -1,11 +1,11 @@
-# from __future__ import absolute_import
-# from ._verify import verify, analyze, registerSimulator
-# from ._toVerilog import toVerilog
-# from ._toVHDL import toVHDL
-#
-# __all__ = ["verify",
-#            "analyze",
-#            "registerSimulator",
-#            "toVerilog",
-#            "toVHDL"
-#            ]
+from __future__ import absolute_import
+from ._verify import verify, analyze, registerSimulator
+from ._toVerilog import toVerilog
+from ._toVHDL import toVHDL
+
+__all__ = ["verify",
+           "analyze",
+           "registerSimulator",
+           "toVerilog",
+           "toVHDL"
+           ]

--- a/myhdl/conversion/__init__.py
+++ b/myhdl/conversion/__init__.py
@@ -1,11 +1,11 @@
-from __future__ import absolute_import
-from ._verify import verify, analyze, registerSimulator
-from ._toVerilog import toVerilog
-from ._toVHDL import toVHDL
-
-__all__ = ["verify",
-           "analyze",
-           "registerSimulator",
-           "toVerilog",
-           "toVHDL"
-           ]
+# from __future__ import absolute_import
+# from ._verify import verify, analyze, registerSimulator
+# from ._toVerilog import toVerilog
+# from ._toVHDL import toVHDL
+#
+# __all__ = ["verify",
+#            "analyze",
+#            "registerSimulator",
+#            "toVerilog",
+#            "toVHDL"
+#            ]

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -363,7 +363,7 @@ def _writeModuleHeader(f, intf, needPck, lib, arch, useClauses, doc, stdLogicPor
             pt = st = _getTypeString(s)
             if convertPort:
                 pt = "std_logic_vector"
-             # Check if VHDL keyword or reused name
+            # Check if VHDL keyword or reused name
             _nameValid(s._name)
             if s._driven:
                 if s._read:
@@ -404,8 +404,24 @@ def _writeTypeDefs(f):
     sortedList = list(_enumTypeSet)
     sortedList.sort(key=lambda x: x._name)
     for t in sortedList:
-        f.write("%s\n" % t._toVHDL())
-    # f.write("\n"
+#         f.write("%s\n" % t._toVHDL())
+        typename, names, codes = t.reftype()
+        for name in names:
+            # watch out _nameValid() will add every name to a check-list
+            # which will force you to be inventive with state names ...
+            # e.g. the typical 'IDLE' can only be used once
+            # so let's pre-fix the enum name
+            # we could have modified _nameValid() to take a default boolean argument
+            _nameValid(''.join((typename, '.', name)))
+
+        enumtypedecl = "type %s is (\n\t" % typename
+        enumtypedecl += ",\n\t".join(names)
+        enumtypedecl += "\n\t);\n"
+        if codes is not None:
+            enumtypedecl += 'attribute enum_encoding of %s: type is "%s";\n' % (typename, codes)
+        f.write('{}'.format(enumtypedecl))
+    # a final blank separator line
+    f.write("\n")
 
 
 constwires = []

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -305,6 +305,24 @@ def _writeFileHeader(f, fn):
     print(file=f)
 
 
+def _writeEnum(f, e):
+    typename, names, codes = e.reftype()
+    for name in names:
+        # watch out _nameValid() will add every name to a check-list
+        # which will force you to be inventive with state names ...
+        # e.g. the typical 'IDLE' can only be used once
+        # so let's pre-fix the enum name
+        # we could have modified _nameValid() to take a default boolean argument
+        _nameValid(''.join((typename, '.', name)))
+
+    enumtypedecl = "type %s is (\n\t" % typename
+    enumtypedecl += ",\n\t".join(names)
+    enumtypedecl += "\n\t);\n"
+    if codes is not None:
+        enumtypedecl += 'attribute enum_encoding of %s: type is "%s";\n' % (typename, codes)
+    f.write('{}'.format(enumtypedecl))
+
+
 def _writeCustomPackage(f, intf):
     print(file=f)
     print("package pck_%s is" % intf.name, file=f)
@@ -314,7 +332,8 @@ def _writeCustomPackage(f, intf):
     sortedList = list(_enumPortTypeSet)
     sortedList.sort(key=lambda x: x._name)
     for t in sortedList:
-        print("    %s" % t._toVHDL(), file=f)
+#         print("    %s" % t._toVHDL(), file=f)
+        _writeEnum(f, t)
     print(file=f)
     print("end package pck_%s;" % intf.name, file=f)
     print(file=f)
@@ -405,21 +424,22 @@ def _writeTypeDefs(f):
     sortedList.sort(key=lambda x: x._name)
     for t in sortedList:
 #         f.write("%s\n" % t._toVHDL())
-        typename, names, codes = t.reftype()
-        for name in names:
-            # watch out _nameValid() will add every name to a check-list
-            # which will force you to be inventive with state names ...
-            # e.g. the typical 'IDLE' can only be used once
-            # so let's pre-fix the enum name
-            # we could have modified _nameValid() to take a default boolean argument
-            _nameValid(''.join((typename, '.', name)))
-
-        enumtypedecl = "type %s is (\n\t" % typename
-        enumtypedecl += ",\n\t".join(names)
-        enumtypedecl += "\n\t);\n"
-        if codes is not None:
-            enumtypedecl += 'attribute enum_encoding of %s: type is "%s";\n' % (typename, codes)
-        f.write('{}'.format(enumtypedecl))
+#         typename, names, codes = t.reftype()
+#         for name in names:
+#             # watch out _nameValid() will add every name to a check-list
+#             # which will force you to be inventive with state names ...
+#             # e.g. the typical 'IDLE' can only be used once
+#             # so let's pre-fix the enum name
+#             # we could have modified _nameValid() to take a default boolean argument
+#             _nameValid(''.join((typename, '.', name)))
+#
+#         enumtypedecl = "type %s is (\n\t" % typename
+#         enumtypedecl += ",\n\t".join(names)
+#         enumtypedecl += "\n\t);\n"
+#         if codes is not None:
+#             enumtypedecl += 'attribute enum_encoding of %s: type is "%s";\n' % (typename, codes)
+#         f.write('{}'.format(enumtypedecl))
+        _writeEnum(f, t)
     # a final blank separator line
     f.write("\n")
 

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -65,6 +65,8 @@ from myhdl.conversion._analyze import (_analyzeSigs, _analyzeGens, _analyzeTopFu
 from myhdl.conversion._toVHDLPackage import _package
 from myhdl.conversion._VHDLNameValidation import _nameValid
 
+from myhdl import bin as tobin
+
 _version = myhdl.__version__.replace('.', '')
 _shortversion = _version.replace('dev', '')
 _converting = 0
@@ -576,13 +578,13 @@ def _convertGens(genlist, siglist, memlist, vfile):
                     pre, suf = "to_signed(", ", %s)" % w
                 else:
                     pre, suf = "signed'(", ")"
-                    c = '"%s"' % bin(c, w)
+                    c = '"%s"' % tobin(c, w)
             else:
                 if w <= 31:
                     pre, suf = "to_unsigned(", ", %s)" % w
                 else:
                     pre, suf = "unsigned'(", ")"
-                    c = '"%s"' % bin(c, w)
+                    c = '"%s"' % tobin(c, w)
         else:
             raise ToVHDLError("Unexpected type for constant signal", s._name)
         print("%s <= %s%s%s;" % (s._name, pre, c, suf), file=vfile)
@@ -665,9 +667,9 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
 
     def BitRepr(self, item, var):
         if isinstance(var._val, bool):
-            return '\'%s\'' % bin(item, len(var))
+            return '\'%s\'' % tobin(item, len(var))
         else:
-            return '"%s"' % bin(item, len(var))
+            return '"%s"' % tobin(item, len(var))
 
     def inferCast(self, vhd, ori):
         pre, suf = "", ""
@@ -972,7 +974,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
                 elif isinstance(lhs.vhd, vhd_int):
                     self.write("%s;" % n)
                 else:
-                    self.write('"%s";' % bin(n, size))
+                    self.write('"%s";' % tobin(n, size))
             self.dedent()
             self.writeline()
             self.write("end case;")
@@ -1157,17 +1159,17 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         elif isinstance(node.vhd, vhd_boolean):
             self.write("%s" % bool(n))
         # elif isinstance(node.vhd, (vhd_unsigned, vhd_signed)):
-        #    self.write('"%s"' % bin(n, node.vhd.size))
+        #    self.write('"%s"' % tobin(n, node.vhd.size))
         elif isinstance(node.vhd, vhd_unsigned):
             if abs(n) < 2 ** 31:
                 self.write("to_unsigned(%s, %s)" % (n, node.vhd.size))
             else:
-                self.write('unsigned\'("%s")' % bin(n, node.vhd.size))
+                self.write('unsigned\'("%s")' % tobin(n, node.vhd.size))
         elif isinstance(node.vhd, vhd_signed):
             if abs(n) < 2 ** 31:
                 self.write("to_signed(%s, %s)" % (n, node.vhd.size))
             else:
-                self.write('signed\'("%s")' % bin(n, node.vhd.size))
+                self.write('signed\'("%s")' % tobin(n, node.vhd.size))
         else:
             if n < 0:
                 self.write("(")
@@ -1425,12 +1427,12 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
                     if abs(obj) < 2 ** 31:
                         s = "to_unsigned(%s, %s)" % (obj, node.vhd.size)
                     else:
-                        s = 'unsigned\'("%s")' % bin(obj, node.vhd.size)
+                        s = 'unsigned\'("%s")' % tobin(obj, node.vhd.size)
                 elif isinstance(node.vhd, vhd_signed):
                     if abs(obj) < 2 ** 31:
                         s = "to_signed(%s, %s)" % (obj, node.vhd.size)
                     else:
-                        s = 'signed\'("%s")' % bin(obj, node.vhd.size)
+                        s = 'signed\'("%s")' % tobin(obj, node.vhd.size)
             elif isinstance(obj, _Signal):
                 s = str(obj)
                 ori = inferVhdlObj(obj)
@@ -1506,10 +1508,10 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             else:
                 if isinstance(node.vhd, vhd_unsigned):
                     pre, post = "unsigned'(", ")"
-                    c = '"%s"' % bin(c, node.vhd.size)
+                    c = '"%s"' % tobin(c, node.vhd.size)
                 elif isinstance(node.vhd, vhd_signed):
                     pre, post = "signed'(", ")"
-                    c = '"%s"' % bin(c, node.vhd.size)
+                    c = '"%s"' % tobin(c, node.vhd.size)
             self.write(pre)
             self.write("%s" % c)
             self.write(post)
@@ -1826,7 +1828,7 @@ def _convertInitVal(reg, init):
         if abs(init) < 2 ** 31:
             v = '%sto_%s(%s, %s)%s' % (pre, vhd_tipe, init, len(reg), suf)
         else:
-            v = '%s%s\'"%s"%s' % (pre, vhd_tipe, bin(init, len(reg)), suf)
+            v = '%s%s\'"%s"%s' % (pre, vhd_tipe, tobin(init, len(reg)), suf)
     else:
         assert isinstance(init, EnumItemType)
         v = init._toVHDL()

--- a/myhdl/test/bugs/test_bug_enum_toVHDL.py
+++ b/myhdl/test/bugs/test_bug_enum_toVHDL.py
@@ -2,32 +2,41 @@ from __future__ import absolute_import
 import myhdl
 from myhdl import *
 
-#t_state = enum('WAIT_POSEDGE', 'WAIT_NEGEDGE', encoding='one_hot')
+# t_state = enum('WAIT_POSEDGE', 'WAIT_NEGEDGE', encoding='one_hot')
 t_state = enum('WAIT_POSEDGE', 'WAIT_NEGEDGE')
 
-def pcie_legacyint_next_state_logic(state_i, next_state_o, next_state_en_o, interrupt_pending_i, interrupt_assert_o):
-        @always_comb
-        def sm_output(): # state machine
-                if state_i==t_state.WAIT_POSEDGE:
-                        interrupt_assert_o.next=0
-                        next_state_en_o   .next=interrupt_pending_i
-                        next_state_o      .next=t_state.WAIT_NEGEDGE
-                elif state_i==t_state.WAIT_NEGEDGE:
-                        interrupt_assert_o.next=1
-                        next_state_en_o   .next=not interrupt_pending_i
-                        next_state_o      .next=t_state.WAIT_POSEDGE
-                else:
-                        interrupt_assert_o.next=0
-                        next_state_en_o   .next=1
-                        next_state_o      .next=t_state.WAIT_POSEDGE
-        return sm_output 
 
-state         = Signal(t_state.WAIT_POSEDGE)
-next_state    = Signal(t_state.WAIT_POSEDGE)
-next_state_en = Signal(bool(0)) # Enable transition to next state
+def pcie_legacyint_next_state_logic(state_i, next_state_o, next_state_en_o, interrupt_pending_i, interrupt_assert_o):
+
+        @always_comb
+        def sm_output():  # state machine
+                if state_i == t_state.WAIT_POSEDGE:
+                        interrupt_assert_o.next = 0
+                        next_state_en_o   .next = interrupt_pending_i
+                        next_state_o      .next = t_state.WAIT_NEGEDGE
+                elif state_i == t_state.WAIT_NEGEDGE:
+                        interrupt_assert_o.next = 1
+                        next_state_en_o   .next = not interrupt_pending_i
+                        next_state_o      .next = t_state.WAIT_POSEDGE
+                else:
+                        interrupt_assert_o.next = 0
+                        next_state_en_o   .next = 1
+                        next_state_o      .next = t_state.WAIT_POSEDGE
+
+        return sm_output
+
+
+state = Signal(t_state.WAIT_POSEDGE)
+next_state = Signal(t_state.WAIT_POSEDGE)
+next_state_en = Signal(bool(0))  # Enable transition to next state
 interrupt_pending = Signal(bool(0))
-interrupt_assert  = Signal(bool(0))
+interrupt_assert = Signal(bool(0))
+
 
 def test_bug_enum_toVHDL():
+    toVHDL(pcie_legacyint_next_state_logic, state, next_state, next_state_en, interrupt_pending, interrupt_assert)
+
+
+if __name__ == '__main__':
     toVHDL(pcie_legacyint_next_state_logic, state, next_state, next_state_en, interrupt_pending, interrupt_assert)
 

--- a/myhdl/test/bugs/test_bug_enum_toVHDL_2.py
+++ b/myhdl/test/bugs/test_bug_enum_toVHDL_2.py
@@ -4,30 +4,37 @@ from myhdl import *
 
 t_state = enum('WAIT_POSEDGE', 'WAIT_NEGEDGE', encoding='one_hot')
 
-def pcie_legacyint_next_state_logic(state_i, next_state_o, next_state_en_o, interrupt_pending_i, interrupt_assert_o):
-        @always_comb
-        def sm_output(): # state machine
-                if state_i==t_state.WAIT_POSEDGE:
-                        interrupt_assert_o.next=0
-                        next_state_en_o   .next=interrupt_pending_i
-                        next_state_o      .next=t_state.WAIT_NEGEDGE
-                elif state_i==t_state.WAIT_NEGEDGE:
-                        interrupt_assert_o.next=1
-                        next_state_en_o   .next=not interrupt_pending_i
-                        next_state_o      .next=t_state.WAIT_POSEDGE
-                else:
-                        interrupt_assert_o.next=0
-                        next_state_en_o   .next=1
-                        next_state_o      .next=t_state.WAIT_POSEDGE
-        return sm_output 
 
-state         = Signal(t_state.WAIT_POSEDGE)
-next_state    = Signal(t_state.WAIT_POSEDGE)
-next_state_en = Signal(bool(0)) # Enable transition to next state
+def pcie_legacyint_next_state_logic(state_i, next_state_o, next_state_en_o, interrupt_pending_i, interrupt_assert_o):
+
+        @always_comb
+        def sm_output():  # state machine
+                if state_i == t_state.WAIT_POSEDGE:
+                        interrupt_assert_o.next = 0
+                        next_state_en_o   .next = interrupt_pending_i
+                        next_state_o      .next = t_state.WAIT_NEGEDGE
+                elif state_i == t_state.WAIT_NEGEDGE:
+                        interrupt_assert_o.next = 1
+                        next_state_en_o   .next = not interrupt_pending_i
+                        next_state_o      .next = t_state.WAIT_POSEDGE
+                else:
+                        interrupt_assert_o.next = 0
+                        next_state_en_o   .next = 1
+                        next_state_o      .next = t_state.WAIT_POSEDGE
+
+        return sm_output
+
+
+state = Signal(t_state.WAIT_POSEDGE)
+next_state = Signal(t_state.WAIT_POSEDGE)
+next_state_en = Signal(bool(0))  # Enable transition to next state
 interrupt_pending = Signal(bool(0))
-interrupt_assert  = Signal(bool(0))
+interrupt_assert = Signal(bool(0))
+
 
 def test_bug_enum_toVHDL_2():
     assert conversion.analyze(pcie_legacyint_next_state_logic, state, next_state, next_state_en, interrupt_pending, interrupt_assert) == 0
 
 
+if __name__ == '__main__':
+    toVHDL(pcie_legacyint_next_state_logic, state, next_state, next_state_en, interrupt_pending, interrupt_assert)


### PR DESCRIPTION
Adding the VHDL keyword check for ```enum``` member names. (-> @hgomersall )
Also reworked the _nameValid() to check for any casing of the submitted *name*.
Rewrote the code replacing *for loops* with python string methods. 