### PR TITLE
add simple debug info module

### DIFF
--- a/myhdl/debug.py
+++ b/myhdl/debug.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import platform
+
+from . import __version__
+
+
+def print_versions():
+    versions = [
+        ("myhdl", __version__),
+        ("Python Version", platform.python_version()),
+        ("Python Implementation", platform.python_implementation()),
+        ("OS", platform.platform()),
+    ]
+
+    print()
+    print("INSTALLED VERSIONS")
+    print("------------------")
+    for k, v in versions:
+        print("{}: {}".format(k, v))
+
+
+if __name__ == "__main__":
+    print_versions()


### PR DESCRIPTION
```
python -m myhdl.debug

INSTALLED VERSIONS
------------------
myhdl: 0.10
Python Version: 3.7.2
Python Implementation: CPython
OS: Linux-4.20.6-arch1-1-ARCH-x86_64-with-arch
```