### PR TITLE
Fix 316 literals have wrong size

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -2255,7 +2255,8 @@ class _AnnotateTypesVisitor(ast.NodeVisitor, _ConversionMixin):
         if node.n < 0:
             node.vhd = vhd_int()
         else:
-            node.vhd = vhd_nat()
+            # literals should have a size in bits as well
+            node.vhd = vhd_nat(int(math.ceil(math.log(node.n + 1, 2))))
         node.vhdOri = copy(node.vhd)
 
     def visit_For(self, node):

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -905,7 +905,9 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         # vhdl type from UnaryOp node, and visit the modified operand
         if isinstance(node.op, ast.USub) and isinstance(node.operand, ast.Num):
             node.operand.n = -node.operand.n
+            size = node.operand.vhd.size
             node.operand.vhd = node.vhd
+            node.operand.vhd.size = size
             self.visit(node.operand)
             return
         pre, suf = self.inferCast(node.vhd, node.vhdOri)


### PR DESCRIPTION
this should fix #316 (it does at least for the example from the bug report)

```vhdl
library IEEE;
use IEEE.std_logic_1164.all;
use IEEE.numeric_std.all;
use std.textio.all;

use work.pck_myhdl_011.all;

entity tmp is
end entity tmp;

architecture MyHDL of tmp is

signal address: unsigned(3 downto 0);
signal counter: unsigned(7 downto 0) := 8X"00";

begin

address <= to_unsigned(0, 4);

counter <= resize((to_unsigned(240, 8) or address), 8);

end architecture MyHDL;
```