### PR TITLE
RFC: Fix sliceslice code generation

### DIFF
--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -55,11 +55,25 @@ class _SliceSignal(_ShadowSignal):
     __slots__ = ('_sig', '_left', '_right')
 
     def __init__(self, sig, left, right=None):
+        if isinstance(sig, _SliceSignal):
+            if sig._right is not None:
+                if right is None:
+                    right = sig._right
+                else:
+                    right += sig._right
+                left += sig._right
+            sig = sig._sig
+        if isinstance(sig, _ShadowSignal):
+            raise TypeError("_ShadowSignal not supported as sig.")
+
+        sig._slicesigs.append(self)
+
         # XXX error checks
         if right is None:
             _ShadowSignal.__init__(self, sig[left])
         else:
             _ShadowSignal.__init__(self, sig[left:right])
+
         self._sig = sig
         self._left = left
         self._right = right

--- a/myhdl/_Signal.py
+++ b/myhdl/_Signal.py
@@ -340,9 +340,7 @@ class _Signal(object):
 
     ### use call interface for shadow signals ###
     def __call__(self, left, right=None):
-        s = _SliceSignal(self, left, right)
-        self._slicesigs.append(s)
-        return s
+        return _SliceSignal(self, left, right)
 
     ### operators for which delegation to current value is appropriate ###
 


### PR DESCRIPTION
Hi,

given the following code, which slices a slice:
```
from myhdl import *

@block
def test(clk, x, y):
    xs = x(5,2)
    xs = xs(2,0)
#    xs = xs(1,0)

    @always(clk.posedge)
    def logic():
        if xs == 1:
            y.next = 42

    return logic

clk = Signal(False)
x = Signal(intbv(0xAA, 0, 2**8))
y = Signal(intbv(0x55, 0, 2**8))
t = test(clk, x, y)
t.convert("verilog", testbench=False)
```

generates the following Verilog code:
```
module test (
    clk,
    x,
    y
);

input clk;
input [7:0] x;
output [7:0] y;
reg [7:0] y;

always @(posedge clk) begin: TEST_LOGIC
    if ((2 == 1)) begin
        y <= 42;
    end
end

endmodule
```

But that's not quite what I expected.
Apparently it slices the initial value of the signal during the nested slice instead of slicing the signal slice.

After the change from this pull request the generated code looks like this:

```
module test (
    clk,
    x,
    y
);

input clk;
input [7:0] x;
output [7:0] y;
reg [7:0] y;

always @(posedge clk) begin: TEST_LOGIC
    if ((x[4-1:2] == 1)) begin
        y <= 42;
    end
end

endmodule
```

Which looks more like what I would expect.
What do you think?

This pull request is not complete as-is.
I'd just like to get your comments about this change before possibly finalizing it for merge.
Thanks. :)