### PR TITLE
Add +: verilog operator

### DIFF
--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -1216,6 +1216,15 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         # special shortcut case for [:] slice
         if lower is None and upper is None:
             return
+
+        if isinstance(lower, ast.BinOp) and isinstance(lower.left, ast.Name) and isinstance(upper, ast.Name) and upper.id == lower.left.id and isinstance(lower.op, ast.Add):
+            self.write("[")
+            self.visit(upper)
+            self.write("+:")
+            self.visit(lower.right)
+            self.write("]")
+            return
+        
         self.write("[")
         if lower is None:
             self.write("%s" % node.obj._nrbits)

--- a/myhdl/test/conversion/general/test_colon_plus_operator.py
+++ b/myhdl/test/conversion/general/test_colon_plus_operator.py
@@ -1,0 +1,57 @@
+from myhdl import *
+
+@block
+def chunk_buffer(Clk, Reset, Input, Output):
+    OUTPUT_BIT_COUNT = len(Output)
+    idx = Signal(modbv(0)[(len(Input) // OUTPUT_BIT_COUNT):])
+
+    @always_seq(Clk.posedge, reset=Reset)
+    def goto_next():
+        idx.next = idx + 1
+        Output.next = Input[idx + OUTPUT_BIT_COUNT:idx]
+
+    return instances()
+
+@block
+def chunk_buffer_sim(Clk, Reset, Input, Output):
+    chunk_buffer0 = chunk_buffer(Clk, Reset, Input, Output)
+
+    tCK = 20
+    tReset = int(tCK * 3.5)
+    
+    @instance
+    def tb_clk():
+        Clk.next = False
+        yield delay(int(tCK // 2))
+        while True:
+            Clk.next = not Clk
+            yield delay(int(tCK // 2))
+
+    @instance
+    def tb_logic():
+        Reset.next = 1
+        yield delay(tReset)
+        Reset.next = 0
+
+        Input.next = 0xABCDEF
+        
+        for i in range(100):
+            print(Output)
+            yield delay(int(tCK // 2))
+        raise StopSimulation
+            
+    return instances()
+
+def test_top_level_interfaces_verify():
+    Clk = Signal(bool(0))
+    Reset = ResetSignal(0, 1, True)
+    Input = Signal(intbv(0)[256:])
+    Output = Signal(intbv(0)[8:])
+    
+    top_sim = chunk_buffer_sim(Clk, Reset, Input, Output)
+    assert top_sim.verify_convert() == 0
+
+    top = chunk_buffer(Clk, Reset, Input, Output)
+    top.name = 'ChunkBuffer'
+    top.convert('Verilog')
+    top.convert('VHDL')

--- a/myhdl/test/conversion/general/test_colon_plus_operator.py
+++ b/myhdl/test/conversion/general/test_colon_plus_operator.py
@@ -36,7 +36,6 @@ def chunk_buffer_sim(Clk, Reset, Input, Output):
         Input.next = 0xABCDEF
         
         for i in range(100):
-            print(Output)
             yield delay(int(tCK // 2))
         raise StopSimulation
             

--- a/myhdl/test/conversion/general/test_colon_plus_operator.py
+++ b/myhdl/test/conversion/general/test_colon_plus_operator.py
@@ -48,7 +48,7 @@ def test_top_level_interfaces_verify():
     Output = Signal(intbv(0)[8:])
     
     top_sim = chunk_buffer_sim(Clk, Reset, Input, Output)
-    assert top_sim.verify_convert() == 0
+    assert conversion.analyze(top_sim) == 0
 
     top = chunk_buffer(Clk, Reset, Input, Output)
     top.name = 'ChunkBuffer'


### PR DESCRIPTION
The included test generates these error messages:

```
chunk_buffer_sim.v:36: error: A reference to a wire or reg (`chunk_buffer0_idx') is not allowed in a constant expression.
chunk_buffer_sim.v:36: error: Part select expressions must be constant.
chunk_buffer_sim.v:36:      : This lsb expression violates the rule: chunk_buffer0_idx
chunk_buffer_sim.v:36: error: A reference to a wire or reg (`chunk_buffer0_idx') is not allowed in a constant expression.
chunk_buffer_sim.v:36: error: Part select expressions must be constant.
chunk_buffer_sim.v:36:      : This msb expression violates the rule: ((chunk_buffer0_idx)+('sd8))-('sd1)
chunk_buffer_sim.v:36: error: A reference to a wire or reg (`chunk_buffer0_idx') is not allowed in a constant expression.
chunk_buffer_sim.v:36: error: Part select expressions must be constant.
chunk_buffer_sim.v:36:      : This lsb expression violates the rule: chunk_buffer0_idx
chunk_buffer_sim.v:36: error: A reference to a wire or reg (`chunk_buffer0_idx') is not allowed in a constant expression.
chunk_buffer_sim.v:36: error: Part select expressions must be constant.
chunk_buffer_sim.v:36:      : This msb expression violates the rule: ((chunk_buffer0_idx)+('sd8))-('sd1)
```

before the follow-up fix patch. 

Without that patch; it outputs this verilog:

```
        Output <= Input[(idx + 8)-1:idx];
```

and after it outputs this:

```
        Output <= Input[idx+:8];
```