### PR TITLE
Added cosimulation with verilator v4 and https://github.com/csail-csg/pyverilator

### DIFF
--- a/myhdl/_Cosimulation.py
+++ b/myhdl/_Cosimulation.py
@@ -45,6 +45,7 @@ _error.OSError = "OSError"
 class Cosimulation(object):
 
     """ Cosimulation class. """
+    name = 'cosimulation_dut'
 
     def __init__(self, exe="", **kwargs):
         """ Construct a cosimulation object. """

--- a/myhdl/_Verilation.py
+++ b/myhdl/_Verilation.py
@@ -1,0 +1,180 @@
+#  This file is part of the myhdl library, a Python package for using
+#  Python as a Hardware Description Language.
+#
+#  Copyright (C) 2003-2008 Jan Decaluwe
+#  Copyright (C) 2020 Jos Huisken
+#
+#  The myhdl library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation; either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+""" Module that provides the Verilation class
+
+Verilation is a cosimulation method using the verilator.
+No interprocvess communication is required, instead a C++ verilator library
+of the verilog module  is dynamically loaded.
+
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import sys
+import os
+import platform
+try:
+    import pyverilator
+except ImportError as e:
+    pass
+from subprocess import CalledProcessError
+
+#from myhdl.emulation.pinorder import Pinorder
+from myhdl._intbv import intbv
+from myhdl import _simulator, VerilationError
+from myhdl._compat import set_inheritable, string_types, to_bytes, to_str
+from myhdl._simulator import now
+
+_MAXLINE = 4096
+_DEVEL = True
+
+
+class _error:
+    pass
+_error.NoPyVerilator = "No module pyverilator installed"
+_error.NoVerilator = "No verilator available"
+_error.MultipleVerilator = "Cannot load multiple verilators"
+_error.SigNotFound = "Signal not found in Verilation arguments"
+_error.NoCommunication = "No signals communicating to myhdl"
+_error.VerilationEnd = "Premature verilation end"
+_error.OSError = "OSError"
+_error.AssertionError = "AssertionError"
+_error.VerilatorError = "Verilator error"
+
+class _debug:
+    'Trace activity between verilator and myhdl while CoSimulating'
+    count = 0
+    def __init__(self, trcfile):
+        try:
+            self.ptrc = open(trcfile, 'w')
+        except:
+            self.ptrc = False
+    def close(self):
+        self.ptrc and self.ptrc.close()
+        self.ptrc = False
+    def write(self, s):
+        self.ptrc and self.ptrc.write(s)
+
+DBG = _debug('')
+#DBG = _debug('verilator.trc')
+
+class Verilation(object):
+
+    """ Verilation class. """
+    name = 'verilation_dut'
+
+    def __init__(self, top_verilog_file='', sofile='', trace=False, auto_tracing = True, **kwargs):
+        """ Construct an verilation object. """
+
+        try:
+            assert sofile or top_verilog_file, \
+                'Either shared object "sofile" or "top_verilog_file" must be specified'
+            assert not (sofile and top_verilog_file), \
+                'Specified both shared object "%s" and top_verilog "%s" for verilation, using verilog' \
+                % (sofile, top_verilog_file)
+        except AssertionError as e:
+            raise VerilationError(_error.AssertionError, str(e))
+
+        try:
+            if top_verilog_file:
+                self.verilator = pyverilator.PyVerilator.build(top_verilog_file)
+                self.verilator.auto_eval = False
+            else:
+                self.verilator = pyverilator.PyVerilator(sofile, auto_eval=False)
+        except NameError as e:
+            raise VerilationError(_error.NoPyVerilator)
+        except AssertionError as e:
+            raise VerilationError(_error.AssertionError, str(e))
+        except CalledProcessError as e:
+            raise VerilationError(_error.VerilatorError, str(e))
+        except:
+            raise VerilationError(_error.VerilatorError)
+
+        if trace:
+            if type(trace) == str:
+                self.verilator.start_vcd_trace(trace, auto_tracing)
+            self.verilator.start_gtkwave()
+            self.verilator.send_to_gtkwave(self.verilator.io)
+            self.verilator.send_to_gtkwave(self.verilator.internals)
+
+        self._hasChange = 0
+        self._getMode = 1
+
+        self._toSigs = {}
+        self._fromSigs = {}
+        for s, S in self.verilator.all_signals.items():
+            # print("s:", s, S, type(S))
+            if type(S) == pyverilator.Output:
+                self._toSigs[s[0]] = kwargs[s[0]]
+            if type(S) == pyverilator.Input:
+                self._fromSigs[s[0]] = kwargs[s[0]]
+
+    def _get(self):
+        if not self._getMode:
+            return
+        for s, sig in self._toSigs.items():
+            # if sig._nrbits > 64:
+            #     # sc_bv: (more then 64 bits) is array of uint32_t
+            #     # print(self.verilator[s])
+            #     next = self.verilator[s]
+            #     # next = 0
+            #     # for i in range((sig._nrbits - 1) // 32 + 1):
+            #     #     next |= self.verilator[s][i] << (i * 32)
+            # else:
+            #     # either uint32_t or uint64_t
+            #     next = self.verilator[s]
+            if sig != self.verilator[s]:
+                sig.next = self.verilator[s]
+            DBG.write('%3d read- %s %s %s %s\n' % (now(), s, hex(self.verilator[s]), type(sig), sig))
+        self._getMode = 0
+
+    def _put(self, time):
+        # self._hasChange = 1
+        #print('V._put', self._hasChange, end=' ')
+        #print('clk', self._fromSigs['clk'])
+        if self._hasChange:
+            self._hasChange = 0
+            for s, sig in self._fromSigs.items():
+                # if sig._nrbits > 64:
+                #     # sc_bv: (more then 64 bits) is array of uint32_t
+                #     v = []
+                #     for i in range((sig._nrbits + 31) // 32):
+                #         v.append((sig._val >> (i * 32)) & 0xffffffff)
+                #     self.verilator[s] = v
+                # else:
+                #     # either uint32_t or uint64_t
+                #     self.verilator[s] = int(sig._val)
+                self.verilator[s] = int(sig._val)
+                DBG.write('%3d writ- %s %s\n' % (now(), s, hex(sig._val)))
+            self.verilator.eval()
+        self._getMode = 1
+
+    def _waiter(self):
+        sigs = tuple(self._fromSigs.values())
+        while 1:
+            yield sigs
+            self._hasChange = 1
+
+    def __del__(self):
+        """ Clear flag when this object destroyed - to suite unittest. """
+        _simulator._verilate = 0
+        DBG.close()

--- a/myhdl/__init__.py
+++ b/myhdl/__init__.py
@@ -103,6 +103,10 @@ class CosimulationError(Error):
     pass
 
 
+class VerilationError(Error):
+    pass
+
+
 class ExtractHierarchyError(Error):
     pass
 
@@ -156,6 +160,7 @@ from ._ShadowSignal import TristateSignal
 from ._simulator import now
 from ._delay import delay
 from ._Cosimulation import Cosimulation
+from ._Verilation import Verilation
 from ._Simulation import Simulation
 from ._misc import instances, downrange
 from ._always_comb import always_comb
@@ -189,6 +194,7 @@ __all__ = ["bin",
            "downrange",
            "StopSimulation",
            "Cosimulation",
+           "Verilation",
            "Simulation",
            "instances",
            "instance",

--- a/myhdl/_block.py
+++ b/myhdl/_block.py
@@ -27,7 +27,7 @@ import functools
 
 import myhdl
 from myhdl._compat import PY2
-from myhdl import BlockError, BlockInstanceError, Cosimulation
+from myhdl import BlockError, BlockInstanceError, Cosimulation, Verilation
 from myhdl._instance import _Instantiator
 from myhdl._util import _flatten
 from myhdl._extractHierarchy import (_makeMemInfo,
@@ -236,7 +236,7 @@ class _Block(object):
 
     def _verifySubs(self):
         for inst in self.subs:
-            if not isinstance(inst, (_Block, _Instantiator, Cosimulation)):
+            if not isinstance(inst, (_Block, _Instantiator, Cosimulation, Verilation)):
                 raise BlockError(_error.ArgType % (self.name,))
             if isinstance(inst, (_Block, _Instantiator)):
                 if not inst.modctxt:
@@ -250,6 +250,8 @@ class _Block(object):
             # the symdict of a block instance is defined by
             # the call context of its instantiations
             if isinstance(inst, Cosimulation):
+                continue  # ignore
+            if isinstance(inst, Verilation):
                 continue  # ignore
             if self.symdict is None:
                 self.symdict = inst.callinfo.symdict

--- a/myhdl/_misc.py
+++ b/myhdl/_misc.py
@@ -30,11 +30,12 @@ from __future__ import absolute_import
 import inspect
 
 from myhdl._Cosimulation import Cosimulation
+from myhdl._Verilation import Verilation
 from myhdl._instance import _Instantiator
 
 def _isGenSeq(obj):
     from myhdl._block import _Block
-    if isinstance(obj, (Cosimulation, _Instantiator, _Block)):
+    if isinstance(obj, (Cosimulation, Verilation, _Instantiator, _Block)):
         return True
     if not isinstance(obj, (list, tuple, set)):
         return False

--- a/myhdl/test/core/test_Verilation.py
+++ b/myhdl/test/core/test_Verilation.py
@@ -1,0 +1,111 @@
+#  This file is part of the myhdl library, a Python package for using
+#  Python as a Hardware Description Language.
+#
+#  Copyright (C) 2003-2008 Jan Decaluwe
+#
+#  The myhdl library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation; either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+""" Run unit tests for Verilation """
+from __future__ import absolute_import
+
+import gc
+import os
+import sys
+import shutil
+import pytest
+
+if sys.platform == "win32":
+    import msvcrt
+
+from myhdl import Signal, intbv, modbv, block, always, instance, delay, now, StopSimulation
+from myhdl._compat import to_bytes
+from myhdl._Verilation import Verilation, VerilationError, _error
+
+if __name__ != '__main__':
+    from helpers import raises_kind
+
+
+Verilator = True
+try:
+    import pyverilator
+except:
+    Verilator = False
+
+class TestVerilation:
+    def testNoArgs(self):
+        with raises_kind(VerilationError, _error.AssertionError):
+            Verilation(sofile='', top_verilog_file='')
+
+    def testDoubleArgs(self):
+        with raises_kind(VerilationError, _error.AssertionError):
+            Verilation(sofile='a', top_verilog_file='b')
+
+
+@pytest.mark.skipif(Verilator, reason='only needed when there is no (py)verilator')
+class TestWithoutVerilation:
+    def testPyVerilatorMissing(self):
+        with raises_kind(VerilationError, _error.NoPyVerilator):
+            Verilation(top_verilog_file='ttt.v')
+
+from .top import tb_top
+
+@pytest.mark.skipif(not Verilator, reason='no (py)verilator available')
+class TestWithVerilation:
+
+    def setup_method(self, method):
+        gc.collect()
+
+    def testVerilatorMissingFile(self):
+        with raises_kind(VerilationError, _error.VerilatorError):
+            Verilation(top_verilog_file='ttt.v')
+
+    def testVerilatorVerilog(self):
+        v = '''module ttp(); endmodule'''
+        with open('ttp.v', 'w') as f:
+            f.write(v)
+        Verilation(top_verilog_file='ttp.v')
+        # os.remove('ttp.v')
+        # shutil.rmtree('obj_dir')
+
+    def testVerilatorSharedLib(self):
+        v = '''module ttp(); endmodule'''
+        with open('ttp.v', 'w') as f:
+            f.write(v)
+        Verilation(sofile='obj_dir/Vttp')
+        # os.remove('ttp.v')
+        # shutil.rmtree('obj_dir')
+
+    @pytest.mark.skip(reason='would start gtkwave gui probably fails in CI')
+    def testVerilatorSharedLibTrace(self):
+        v = '''module ttp(); endmodule'''
+        with open('ttp.v', 'w') as f:
+            f.write(v)
+        Verilation(sofile='obj_dir/Vttp', trace=True, auto_tracing=False)
+        # os.remove('ttp.v')
+        # shutil.rmtree('obj_dir')
+
+    def testVerilatorSignalTypes(self):
+        tb = tb_top()
+        tb.run_sim()
+        ntb = tb_top(sim='verilator_vrl')
+        ntb.run_sim()
+        # os.remove('top.v')
+        # shutil.rmtree('obj_dir')
+
+
+if __name__ == "__main__":
+    getattr(TestVerilation, sys.argv[1])()
+    getattr(TestWithoutVerilation, sys.argv[1])()
+    getattr(TestWithVerilation, sys.argv[1])()

--- a/myhdl/test/core/top.py
+++ b/myhdl/test/core/top.py
@@ -1,0 +1,111 @@
+import os
+from myhdl import *
+
+@block
+def top(clk, rst, out80, out48, out8):
+    counter = Signal(modbv(0)[len(out80):])
+    m8  = out8.max - 1
+    m48 = out48.max - 1
+    m80 = out80.max - 1
+    @always(clk.posedge)
+    def cnt():
+        if rst:
+            out8.next  = intbv(0x93)[len(out8):]
+            out48.next = intbv(0x3400123400)[len(out48):]
+            out80.next = intbv(0x123400001234000066)[len(out80):]
+            counter.next = intbv(0x3400004321000066)[len(out80):]
+        else:
+            out8.next  = counter[8:] & m8
+            out48.next = counter[48:] & m48
+            out80.next = counter & m80
+            counter.next = counter + 1
+
+    return cnt
+
+@block
+def tb_top(sim = 'myhdl'):
+
+    clk = Signal(bool(0))
+    rst = Signal(bool(0))
+    out8 = Signal(intbv(0)[8:])
+    out48 = Signal(intbv(55)[48:])
+    out80 = Signal(intbv(0)[80:])
+    s = {
+        'clk':   clk,
+        'rst':   rst,
+        'out8':  out8,
+        'out48': out48,
+        'out80': out80
+    }
+
+    @always(clk.posedge)
+    def dsp():
+        print("%g\t %1x   %1x %20x %12x %2x" %
+      	      (now(), clk, rst, out80, out48, out8))
+    
+    @instance
+    def stim():
+        print("time\tclk rst %20s %12s %s" % ('out80', 'out48', 'out8'))
+        yield delay(20)
+        rst.next = 1
+        yield delay(10)
+        rst.next = 0
+        yield delay(80)
+        rst.next = 1
+        yield delay(10)
+        rst.next = 0
+        yield delay(50)
+        print("%g\t %1x   %1x %20x %12x %2x" %
+      	      (now(), clk, rst, out80, out48, out8))
+        assert out8 == 0x6a
+        assert out48 == 0x432100006a
+        assert out80 == 0x340000432100006a
+        raise StopSimulation
+
+    @always(delay(5))
+    def ck():
+        clk.next = not clk
+
+    if sim == 'myhdl':
+        print("myhdl")
+        dut = top(clk, rst, out80, out48, out8)
+        dut.convert(hdl='Verilog')
+    elif sim == 'icarus':
+        print("icarus")
+        cmd = 'iverilog -o top top.v tb_top.v'
+        os.system(cmd)
+        dut = Cosimulation('vvp -m ../../icarus/myhdl_11.0-devel.vpi top', **s)
+        print(dut, dir(dut))
+    elif sim == 'verilator_vrl':
+        print("verilator verilog")
+        # dut = Verilation(top_verilog_file='t.v', trace='t.vcd', **s)
+        dut = Verilation(top_verilog_file='top.v', **s)
+    else:
+        print("verilator shared library")
+        # dut = Verilation(sofile='obj_dir/Vtop', trace=False, **s)
+        dut = Verilation(sofile='obj_dir/Vtop', **s)
+        print(dut, dir(dut))
+
+    return dut, stim, ck, dsp
+
+
+if __name__ == "__main__":
+
+    from pprint import pprint
+
+    tb = tb_top()
+    # pprint(dir(tb))
+    # pprint(tb.sigdict)
+    tb.config_sim(trace=True)
+    tb.run_sim()
+
+    ntb = tb_top(sim='icarus')
+    ntb.run_sim()
+
+    ntb = tb_top(sim='verilator_vrl')
+    ntb.run_sim()
+
+    ntb = tb_top(sim='verilator_shared')
+    ntb.run_sim()
+
+    # pprint(tb.sigdict)


### PR DESCRIPTION
Cosimulation with verilator.

I used ‘pyverilator’ to ease integration. It is a specific version https://github.com/csail-csg/pyverilator which allows easy dictionary access to io-ports.
No interprocess communication is used since the verilated design is imported as a ctypes module.

Several tests have been added. Some are skipped automatically whether pyverilator is installed or not. So it should not break anything.

Automatic merge fails on myhdl/_block.py after 10-april upstream update: something easy to fix.

What I noticed is that both this verilator cosim, but also other cosims like icarus, have some initialization/reset issues which deserve some attention. They behave slightly different than pure myhdl.

Also, I considered to not use pyverilator and rewrite directly for verilator directly, but with this pyverilator version it was more convenient. but anyway, something to reconsider.