### PR TITLE
Use first value instead of -1 as index in for loops

### DIFF
--- a/myhdl/conversion/_analyze.py
+++ b/myhdl/conversion/_analyze.py
@@ -707,13 +707,18 @@ class _AnalyzeVisitor(ast.NodeVisitor, _ConversionMixin):
         self.refStack.push()
         self.visit(node.target)
         var = node.target.id
-        self.tree.vardict[var] = int(-1)
 
         cf = node.iter
         self.visit(cf)
         self.require(node, isinstance(cf, ast.Call), "Expected (down)range call")
         f = self.getObj(cf.func)
         self.require(node, f in (range, downrange), "Expected (down)range call")
+
+        # Use the first value if it exists
+        try:
+            self.tree.vardict[var] = self.getVal(cf)[0]
+        except IndexError:
+            self.tree.vardict[var] = int(-1)
 
         for stmt in node.body:
             self.visit(stmt)


### PR DESCRIPTION
In some circumstances, -1 might end up being used as e.g. an intbv
index which is then invalid. To avoid this, it makes sense to stay
within the given range during analysis. Try to do so by simply picking
the first value from the range.

----

So, for the heck of it, I was trying to port some old code (myhdl 0.8, python2) to myhdl 0.10, python 3).

The line https://github.com/benzea/nco/blob/python3/prng/rule30.py#L50 fails though, because myhdl hardcodes the index to -1, and a -1 index access is invalid for intbv. A commit like this one should fix the issue, by trying to pick a value that is within the user given range.