### PR TITLE
replace yield_fixture decorator by fixture

### DIFF
--- a/myhdl/test/core/test_traceSignals.py
+++ b/myhdl/test/core/test_traceSignals.py
@@ -114,7 +114,7 @@ def topTristate():
     return inst
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def vcd_dir(tmpdir):
     with tmpdir.as_cwd():
         yield tmpdir


### PR DESCRIPTION
https://docs.pytest.org/en/latest/yieldfixture.html

> Since pytest-3.0, fixtures using the normal fixture decorator can use a yield statement to provide fixture values and execute teardown code, exactly like yield_fixture in previous versions.
> 
> Marking functions as yield_fixture is still supported, but deprecated and should not be used in new code.