### PR TITLE
Removed 'casez' in Verilog onehot / onecold state encoding

### DIFF
--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -471,6 +471,7 @@ def _getSignString(s):
     else:
         return ''
 
+
 def _intRepr(n, radix=''):
     # write size for large integers (beyond 32 bits signed)
     # with some safety margin
@@ -478,17 +479,18 @@ def _intRepr(n, radix=''):
     p = abs(n)
     size = ''
     num = str(p).rstrip('L')
-    if radix == "hex" or p >= 2**30:
+    if radix == "hex" or p >= 2 ** 30:
         radix = "'h"
         num = hex(p)[2:].rstrip('L')
-    if p >= 2**30:
-        size = int(math.ceil(math.log(p+1,2))) + 1  # sign bit!
+    if p >= 2 ** 30:
+        size = int(math.ceil(math.log(p + 1, 2))) + 1  # sign bit!
 #            if not radix:
 #                radix = "'d"
     r = "%s%s%s" % (size, radix, num)
-    if n < 0: # add brackets and sign on negative numbers
+    if n < 0:  # add brackets and sign on negative numbers
         r = "(-%s)" % r
     return r
+
 
 def _convertGens(genlist, vfile):
     blockBuf = StringIO()
@@ -1005,11 +1007,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
 #        if node.isFullCase:
 #            self.write(" full_case")
 #        self.writeline()
-        caseType = "case"
-        if isinstance(node.caseItem, EnumItemType):
-            if node.caseItem._type._encoding in ('one_hot', 'one_cold'):
-                caseType = "casez"
-        self.write("%s (" % caseType)
+        self.write("case (")
         self.visit(var)
         self.write(")")
         self.indent()
@@ -1017,7 +1015,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             self.writeline()
             item = test.case[1]
             if isinstance(item, EnumItemType):
-                self.write(item._toVerilog(dontcare=True))
+                self.write(item._toVerilog())
             else:
                 self.write(self.IntRepr(item, radix='hex'))
             self.write(": begin")
@@ -1215,7 +1213,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             self.visit(lower.right)
             self.write("]")
             return
-        
+
         self.write("[")
         if lower is None:
             self.write("%s" % node.obj._nrbits)
@@ -1406,7 +1404,7 @@ def _convertInitVal(reg, init):
     if tipe is bool:
         v = '1' if init else '0'
     elif tipe is intbv:
-        init = int(init) # int representation
+        init = int(init)  # int representation
         v = "%s" % init if init is not None else "'bz"
     else:
         assert isinstance(init, EnumItemType)

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -1099,7 +1099,8 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             self.visit(stmt)
 
     def visit_ListComp(self, node):
-        pass  # do nothing
+        # do nothing
+        pass
 
     def visit_Name(self, node):
         if isinstance(node.ctx, ast.Store):


### PR DESCRIPTION
Fixes: One-hot state machine conversion to Verilog #356