### PR TITLE
Conversion with recursive ShadowSignals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ myhdl/**/*.vhd
 
 # Pycharm ide junk
 .idea/
+/.pytest_cache/

--- a/myhdl/_ShadowSignal.py
+++ b/myhdl/_ShadowSignal.py
@@ -17,10 +17,10 @@
 #  License along with this library; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-""" Module that provides the ShadowSignal classes
-
-
+""" 
+    Module that provides the ShadowSignal classes
 """
+
 import warnings
 from copy import deepcopy
 

--- a/myhdl/_intbv.py
+++ b/myhdl/_intbv.py
@@ -24,12 +24,12 @@ from myhdl._bin import bin
 
 
 class intbv(object):
-    #__slots__ = ('_val', '_min', '_max', '_nrbits', '_handleBounds')
+    # __slots__ = ('_val', '_min', '_max', '_nrbits', '_handleBounds')
 
     def __init__(self, val=0, min=None, max=None, _nrbits=0):
         if _nrbits:
             self._min = 0
-            self._max = 2**_nrbits
+            self._max = 2 ** _nrbits
         else:
             self._min = min
             self._max = max
@@ -476,14 +476,14 @@ class intbv(object):
             # I would prefer sign extension with hex format, but to
             # align with Verilog $display I don't do that
             if v < 0:
-                v = 2**nrbits + v
+                v = 2 ** nrbits + v
             w = (nrbits - 1) // 4 + 1
             return "{:0{w}x}".format(v, w=w)
         else:
             return "{:x}".format(v)
 
     def __repr__(self):
-        return "intbv(" + repr(self._val) + ")"
+        return "intbv(" + repr(self._val) + ")[{}:]".format(self._nrbits)
 
     def signed(self):
         ''' Return new intbv with the values interpreted as signed
@@ -541,7 +541,7 @@ class intbv(object):
             retVal = self._val
 
         if self._nrbits:
-            M = 2**(self._nrbits - 1)
+            M = 2 ** (self._nrbits - 1)
             return intbv(retVal, min=-M, max=M)
         else:
             return intbv(retVal)
@@ -561,4 +561,4 @@ class intbv(object):
         if self._nrbits:
             return intbv(retVal)[self._nrbits:]
         else:
-            return intbv(retVal)        
+            return intbv(retVal)

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -375,6 +375,7 @@ def _writeModuleHeader(f, intf, needPck, lib, arch, useClauses, doc, stdLogicPor
             if stdLogicPorts and s._type is intbv:
                 s._name = portname + "_num"
                 convertPort = True
+                # override the names given by _analyze.py
                 for sl in s._slicesigs:
                     sl._setName('VHDL')
             else:

--- a/myhdl/test/conversion/general/test_ShadowSignal.py
+++ b/myhdl/test/conversion/general/test_ShadowSignal.py
@@ -46,7 +46,7 @@ def bench_RecurseShadowSignal():
     @instance
     def check():
         for i in range(25):
-            s.next = 0x12345678 + i * 39
+            s.next = 0x4567 + i * 39
             yield delay(10)
             print(s)
             print(int(su))

--- a/myhdl/test/conversion/general/test_ShadowSignal.py
+++ b/myhdl/test/conversion/general/test_ShadowSignal.py
@@ -56,6 +56,8 @@ def bench_RecurseShadowSignal():
             print(slu)
             print(sll)
 
+    return check
+
 
 def test_RecurseShadowSignal():
     assert conversion.verify(bench_RecurseShadowSignal()) == 0

--- a/myhdl/test/conversion/general/test_ShadowSignal.py
+++ b/myhdl/test/conversion/general/test_ShadowSignal.py
@@ -1,12 +1,14 @@
-import myhdl
-from myhdl import *
+from myhdl import (block, Signal, intbv, delay, always_comb, instance,
+                   TristateSignal, ConcatSignal, conversion, StopSimulation,
+                   toVerilog, toVHDL)
+
 
 @block
 def bench_SliceSignal():
 
     s = Signal(intbv(0)[8:])
     a, b, c = s(7), s(5), s(0)
-    d, e, f, g = s(8,5), s(6,3), s(8,0), s(4,3)
+    d, e, f, g = s(8, 5), s(6, 3), s(8, 0), s(4, 3)
     N = len(s)
 
     @instance
@@ -30,6 +32,36 @@ def test_SliceSignal():
 
 
 @block
+def bench_RecurseShadowSignal():
+    s = Signal(intbv(0)[16:])
+
+    # take some recursive ShadowSignals
+    su = s(16, 8)
+    sl = s(8, 0)
+    suu = su(8, 4)
+    sul = su(4, 0)
+    slu = sl(8, 4)
+    sll = sl(4, 0)
+
+    @instance
+    def check():
+        for i in range(25):
+            s.next = 0x12345678 + i * 39
+            yield delay(10)
+            print(s)
+            print(int(su))
+            print(int(sl))
+            print(suu)
+            print(sul)
+            print(slu)
+            print(sll)
+
+
+def test_RecurseShadowSignal():
+    assert conversion.verify(bench_RecurseShadowSignal()) == 0
+
+
+@block
 def bench_ConcatSignal():
 
     a = Signal(intbv(0)[5:])
@@ -39,10 +71,11 @@ def bench_ConcatSignal():
 
     s = ConcatSignal(a, b, c, d)
 
-    I_max = 2**len(a)
-    J_max = 2**len(b)
-    K_max = 2**len(c)
-    M_max = 2**len(d)
+    I_max = 2 ** len(a)
+    J_max = 2 ** len(b)
+    K_max = 2 ** len(c)
+    M_max = 2 ** len(d)
+
     @instance
     def check():
         for i in range(I_max):
@@ -58,8 +91,10 @@ def bench_ConcatSignal():
 
     return check
 
+
 def test_ConcatSignal():
     assert conversion.verify(bench_ConcatSignal()) == 0
+
 
 @block
 def bench_ConcatSignalWithConsts():
@@ -78,17 +113,18 @@ def bench_ConcatSignalWithConsts():
 
     s = ConcatSignal(c1, a, c2, b, c3, c, c4, d, c5, e)
 
-    I_max = 2**len(a)
-    J_max = 2**len(b)
-    K_max = 2**len(c)
-    M_max = 2**len(d)
+    I_max = 2 ** len(a)
+    J_max = 2 ** len(b)
+    K_max = 2 ** len(c)
+    M_max = 2 ** len(d)
+
     @instance
     def check():
         for i in range(I_max):
             for j in range(J_max):
                 for k in range(K_max):
                     for m in range(M_max):
-                        for n in range(2**len(e)):
+                        for n in range(2 ** len(e)):
                             a.next = i
                             b.next = j
                             c.next = k
@@ -117,7 +153,7 @@ def bench_TristateSignal():
         b.next = None
         c.next = None
         yield delay(10)
-        #print s
+        # print s
         a.next = 1
         yield delay(10)
         print(s)
@@ -131,7 +167,7 @@ def bench_TristateSignal():
         print(s)
         c.next = None
         yield delay(10)
-        #print s
+        # print s
 
     return check
 
@@ -168,7 +204,7 @@ def bench_permute(conv=False):
 
     @instance
     def stimulus():
-        for i in range(2**len(a)):
+        for i in range(2 ** len(a)):
             a.next = i
             yield delay(10)
             print("%d %d" % (x, a))
@@ -179,8 +215,10 @@ def bench_permute(conv=False):
 
     return dut, stimulus
 
+
 def test_permute():
     assert conversion.verify(bench_permute()) == 0
+
 
 bench_permute(toVHDL)
 bench_permute(toVerilog)


### PR DESCRIPTION
When using recursion and taking ShadowSignal from a ShadowSignal the conversion (both Verilog and VHDL) looses the connection with the starting Signal. This PR fixes that.

_ShadowSignal.py: conversion:
  enabled taking a ShadowSignal of a ShadowSignal,
  reworked _setName() to aggregate chained slicing/indexing to a single slice or index
  marked the shadowed Signal as  always 'read'
_intbv.py: added the [n:] to __repr__
_toVHDL.py: added a comment