### PR TITLE
Fix a typo in an error message - integeer -> integer

### DIFF
--- a/myhdl/_delay.py
+++ b/myhdl/_delay.py
@@ -18,7 +18,7 @@
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 """ Module that provides the delay class."""
-_errmsg = "arg of delay constructor should be a natural integeer"
+_errmsg = "arg of delay constructor should be a natural integer"
 
 
 class delay(object):


### PR DESCRIPTION
Sorry for the noise… 