### PR TITLE
Update flow to compile and used cached version of GHDL/Icarus

### DIFF
--- a/.github/workflows/build_ghdl.yml
+++ b/.github/workflows/build_ghdl.yml
@@ -1,0 +1,35 @@
+name: Build GHDL
+
+on: 
+  #push: 
+  schedule:
+    - cron: '0 0 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  
+jobs:
+  build_dep:
+    uses: daxzio/setup-eda/.github/workflows/setup_ghdl.yml@main
+
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    needs: [build_dep]
+    steps:
+      - name: Cache GHDL
+        uses: actions/cache@v3
+        with:
+          path: ${{ needs.build_dep.outputs.cache_dir }}
+          key: ${{ needs.build_dep.outputs.cache_key }}
+      - name: Add to PATH
+        run: |
+          echo "${{ needs.build_dep.outputs.cache_dir }}/bin" >> $GITHUB_PATH
+      
+      - name: Report GHDL
+        run: |
+          sudo apt install gnat
+          which ghdl
+          ghdl version

--- a/.github/workflows/build_iverilog.yml
+++ b/.github/workflows/build_iverilog.yml
@@ -1,0 +1,33 @@
+name: Build Icarus
+
+on: 
+  #push: 
+  schedule:
+    - cron: '0 0 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  
+jobs:
+  build_dep:
+    uses: daxzio/setup-eda/.github/workflows/setup_iverilog.yml@main
+
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    needs: [build_dep]
+    steps:
+      - name: Cache Icarus
+        uses: actions/cache@v3
+        with:
+          path: ${{ needs.build_dep.outputs.cache_dir }}
+          key: ${{ needs.build_dep.outputs.cache_key }}
+      - name: Add to PATH
+        run: |
+          echo "${{ needs.build_dep.outputs.cache_dir }}/bin" >> $GITHUB_PATH
+      
+      - name: Report Icarus
+        run: |
+          which iverilog

--- a/.github/workflows/setup_ghdl.yml
+++ b/.github/workflows/setup_ghdl.yml
@@ -1,0 +1,60 @@
+name: Setup GHDL
+
+on: 
+  workflow_call:
+    inputs:
+      githash:
+        description: "Allow a githash/tag/branch to be passed as an input"
+        required: false
+        type: string
+    outputs:
+      cache_dir:
+        description: "The Cache Directory"
+        value: ${{ jobs.build.outputs.output0 }}
+      cache_key:
+        description: "The Cache Key"
+        value: ${{ jobs.build.outputs.output1 }}
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      output0 : ${{ steps.step0.outputs.cache_dir }}
+      output1 : ${{ steps.step1.outputs.cache_key }}
+    steps:
+      - name: Test for GITHASH input
+        if: ${{ inputs.githash != '' }}
+        run: |
+          echo "GITHEAD=${{ inputs.githash }}" >> $GITHUB_ENV
+      - name: Setup GHDL 
+        run: |
+          export GITPATH=https://github.com/ghdl/ghdl.git
+          if [ -z ${GITHEAD+x} ]; then
+            export GITHEAD=`git ls-remote $GITPATH HEAD | head -1 | awk '{print $1}'`
+            echo "GITHEAD=${GITHEAD}" >> $GITHUB_ENV
+          fi
+          echo "GITPATH=${GITPATH}" >> $GITHUB_ENV
+          echo "CACHE_DIR=${{ github.workspace }}/.cache/ghdl" >> $GITHUB_ENV
+          echo "CACHE_KEY=ghdl-${GITHEAD}" >> $GITHUB_ENV
+      - name: Cache Environment
+        id: git-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: ${{ env.CACHE_KEY }}
+      - if: ${{ steps.git-cache.outputs.cache-hit != 'true' }}
+        name: Compile GHDL 
+        run: |
+          mkdir -p ${{ env.CACHE_DIR }}
+          git clone ${{ env.GITPATH }}
+          cd ghdl
+          git checkout ${{ env.GITHEAD }}
+          sudo apt install gnat
+          ./configure --prefix=${{ env.CACHE_DIR }}
+          make -j$(nproc)
+          sudo make install
+          cd ..
+      - id: step0
+        run: echo "cache_dir=${{ env.CACHE_DIR }}" >> $GITHUB_OUTPUT
+      - id: step1
+        run: echo "cache_key=${{ env.CACHE_KEY }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/setup_iverilog.yml
+++ b/.github/workflows/setup_iverilog.yml
@@ -1,0 +1,62 @@
+
+name: Setup Iverilog
+
+on: 
+  workflow_call:
+    inputs:
+      githash:
+        description: "Allow a githash/tag/branch to be passed as an input"
+        required: false
+        type: string
+    outputs:
+      cache_dir:
+        description: "The Cache Directory"
+        value: ${{ jobs.build.outputs.output0 }}
+      cache_key:
+        description: "The Cache Key"
+        value: ${{ jobs.build.outputs.output1 }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      output0 : ${{ steps.step0.outputs.cache_dir }}
+      output1 : ${{ steps.step1.outputs.cache_key }}
+    steps:
+      - name: Test for GITHASH input
+        if: ${{ inputs.githash != '' }}
+        run: |
+          echo "GITHEAD=${{ inputs.githash }}" >> $GITHUB_ENV
+      - name: Setup Icarus 
+        run: |
+          export GITPATH=https://github.com/steveicarus/iverilog.git
+          if [ -z ${GITHEAD+x} ]; then
+            export GITHEAD=`git ls-remote $GITPATH HEAD | head -1 | awk '{print $1}'`
+            echo "GITHEAD=${GITHEAD}" >> $GITHUB_ENV
+          fi
+          echo "GITPATH=${GITPATH}" >> $GITHUB_ENV
+          echo "CACHE_DIR=${{ github.workspace }}/.cache/iverilog" >> $GITHUB_ENV
+          echo "CACHE_KEY=iverilog-${GITHEAD}" >> $GITHUB_ENV
+      - name: Cache Environment
+        id: git-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: ${{ env.CACHE_KEY }}
+      - if: ${{ steps.git-cache.outputs.cache-hit != 'true' }}
+        name: Compile Icarus 
+        run: |
+          mkdir -p ${{ env.CACHE_DIR }}
+          git clone ${{ env.GITPATH }}
+          cd iverilog
+          git checkout ${{ env.GITHEAD }}
+          sudo apt install -y build-essential gperf flex bison
+          autoconf
+          ./configure --prefix=${{ env.CACHE_DIR }}
+          make -j$(nproc)
+          sudo make install
+          cd ..
+      - id: step0
+        run: echo "cache_dir=${{ env.CACHE_DIR }}" >> $GITHUB_OUTPUT
+      - id: step1
+        run: echo "cache_key=${{ env.CACHE_KEY }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test_checkin.yml
+++ b/.github/workflows/test_checkin.yml
@@ -4,17 +4,25 @@ on:
   push: 
   pull_request:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 1 * * 0'
 jobs:
-  build:
+  build_ghdl:
+    #uses: daxzio/setup-eda/.github/workflows/setup_ghdl.yml@main
+    uses: ./.github/workflows/setup_ghdl.yml
+  build_iverilog:
+    #uses: daxzio/setup-eda/.github/workflows/setup_iverilog.yml@main
+    uses: ./.github/workflows/setup_iverilog.yml
 
-    runs-on: ${{ matrix.os }}
+  build_code:
+
     strategy:
       fail-fast: false # So that one fail doesn't stop remaining tests
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.9", "3.11"]
         os: [ubuntu-latest]
         target: [core, iverilog, ghdl]
+    runs-on: ${{ matrix.os }}
+    needs: [build_ghdl, build_iverilog]
 
     env:
       CI_TARGET: ${{ matrix.target }}
@@ -22,8 +30,22 @@ jobs:
     
     steps:
       - uses: actions/checkout@v3
+      - name: Cache GHDL
+        uses: actions/cache@v3
+        with:
+          path: ${{ needs.build_ghdl.outputs.cache_dir }}
+          key: ${{ needs.build_ghdl.outputs.cache_key }}
+      - name: Cache Icarus
+        uses: actions/cache@v3
+        with:
+          path: ${{ needs.build_iverilog.outputs.cache_dir }}
+          key: ${{ needs.build_iverilog.outputs.cache_key }}
+      - name: Add to PATH
+        run: |
+          echo "${{ needs.build_ghdl.outputs.cache_dir }}/bin" >> $GITHUB_PATH
+          echo "${{ needs.build_iverilog.outputs.cache_dir }}/bin" >> $GITHUB_PATH
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -33,21 +55,10 @@ jobs:
       - name: Report Environment
         run: |
           echo "Runing tests with env set to : ${CI_TARGET}"
-      - name: Install iverilog
-        if: ${{ env.CI_TARGET == 'iverilog' }}
-        run: |
-            sudo apt-get -qq update;
-            sudo apt-get install -y iverilog;
-      - name: Install ghdl
+      - name: Install depenacy for ghdl
         if: ${{ env.CI_TARGET == 'ghdl' }}
         run: |
-            git clone https://github.com/ghdl/ghdl.git;
-            cd ghdl;
-            sudo apt install gnat;
-            ./configure --prefix=/usr/local;
-            make;
-            sudo make install;
-            cd ..;
+          sudo apt install gnat
       - name: Run Tests
         run: |
           ./scripts/ci.sh

--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -1,0 +1,46 @@
+name: Check cached Setup
+
+on: 
+  #push: 
+  schedule:
+    - cron: '0 1 * * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  
+jobs:
+  build_ghdl:
+    uses: ./.github/workflows/setup_ghdl.yml
+  check_ghdl:
+    runs-on: ubuntu-latest
+    needs: build_ghdl
+    steps:
+      - name: Cache GHDL
+        uses: actions/cache@v3
+        with:
+          path: ${{ needs.build_ghdl.outputs.cache_dir }}
+          key: ${{ needs.build_ghdl.outputs.cache_key }}
+      - name: Add to PATH
+        run: |
+          echo "${{ needs.build_ghdl.outputs.cache_dir }}/bin" >> $GITHUB_PATH
+      - name: Report GHDL
+        run: |
+          which ghdl
+
+  build_iverilog:
+    uses: ./.github/workflows/setup_iverilog.yml
+  check_iverilog:
+    runs-on: ubuntu-latest
+    needs: build_iverilog
+    steps:
+      - name: Cache Icarus
+        uses: actions/cache@v3
+        with:
+          path: ${{ needs.build_iverilog.outputs.cache_dir }}
+          key: ${{ needs.build_iverilog.outputs.cache_key }}
+      - name: Add to PATH
+        run: |
+          echo "${{ needs.build_iverilog.outputs.cache_dir }}/bin" >> $GITHUB_PATH
+      - name: Report Icarus
+        run: |
+          which iverilog


### PR DESCRIPTION
I have improved the github actions so that it compiles the tools, GHDL and icarus, from source, but separate as a dependency that is cacheable.  If not in the cache it will compile, and if cached it will reload.

Please view a successful run to view operation:

https://github.com/daxzio/myhdl/actions/runs/3638199981

This is a fall out of work I have done over here:

https://github.com/daxzio/setup-eda

The cached version is tracked by the githash of the tool.

This saves run time as previously the tools are being compiled for every step which is all the versions of python under test.

If you are doing multiple runs in a week and the tooled version is in cache it will reload.