### PR TITLE
Fixes issue #388 incorrect conversion of `elif siga ==  expression`

### DIFF
--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -1046,7 +1046,9 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             if isinstance(item, EnumItemType):
                 self.write(item._toVerilog())
             else:
-                self.write(self.IntRepr(item, radix='hex'))
+                # we can assume there will only be one comparison
+                # i.o.w. (el)if 1 < a <= 10: is not recognized
+                self.visit(test.comparators[0])
             self.write(": begin")
             self.indent()
             self.visit_stmt(suite)


### PR DESCRIPTION
_toVerilog.py:
  corrected mapToCase conversion of 'test'; replacing integer output by visit(test.comparators[0])
  this will properly convert tests like e.g.  (el)if siga == constb // integer