### PR TITLE
Binops convert in VHDL fix

### DIFF
--- a/myhdl/test/conversion/general/test_binops.py
+++ b/myhdl/test/conversion/general/test_binops.py
@@ -2,7 +2,6 @@ from myhdl import *
 
 @block
 def binOpsCheck (
-    clk,
     a,
     b,
     c,
@@ -18,18 +17,6 @@ def binOpsCheck (
         z.next = a | b | c
 
     return instances()
-
-# def maskedDataSetup():
-#     clk = Signal(bool(0)) 
-#     a   = Signal(modbv(0)[1:])
-#     b   = Signal(modbv(0)[1:])
-#     c   = Signal(modbv(0)[1:])
-#     x   = Signal(modbv(0)[1:])
-#     y   = Signal(modbv(0)[1:])
-#     z   = Signal(modbv(0)[1:])
-    
-#     i_maskedData = maskedData(clk, data_in, sel, data_out)
-#     return i_maskedData
 
 @block
 def binOpsCheckBench0():
@@ -49,8 +36,6 @@ def binOpsCheckBench0():
             yield delay(10)
             clk.next = not clk
 
-
-    
     @instance
     def stimulus():
         a.next = 0x0
@@ -139,7 +124,7 @@ def binOpsCheckBench0():
         assert z == 0x0
         yield clk.posedge
    
-    i_binOpsCheck = binOpsCheck(clk, a, b, c, x, y, z)
+    i_binOpsCheck = binOpsCheck(a, b, c, x, y, z)
 
 
     return instances()
@@ -250,8 +235,7 @@ def binOpsCheckBench1():
         assert z == 0x0
         yield clk.posedge
    
-    i_binOpsCheck = binOpsCheck(clk, a, b, c, x, y, z)
-
+    i_binOpsCheck = binOpsCheck(a, b, c, x, y, z)
 
     return instances()
 
@@ -362,7 +346,7 @@ def binOpsCheckBench2():
         assert z == 0x0
         yield clk.posedge
    
-    i_binOpsCheck = binOpsCheck(clk, a, b, c, x, y, z)
+    i_binOpsCheck = binOpsCheck(a, b, c, x, y, z)
 
 
     return instances()
@@ -388,7 +372,6 @@ def test_binOps1_convert():
     #assert i_dut.verify_simulator() == 0
    
 def test_binOps1b_convert():
-    clk = Signal(bool(0)) 
     a   = Signal(modbv(0)[1:])
     b   = Signal(modbv(0)[1:])
     c   = Signal(modbv(0)[1:])
@@ -396,11 +379,10 @@ def test_binOps1b_convert():
     y   = Signal(False)
     z   = Signal(False)
 
-    i_dut = binOpsCheck(clk, a, b, c, x, y, z)
+    i_dut = binOpsCheck(a, b, c, x, y, z)
     assert i_dut.analyze_convert() == 0
  
 def test_binOps1c_convert():
-    clk = Signal(bool(0)) 
     a   = Signal(intbv(0)[1:])
     b   = Signal(intbv(0)[1:])
     c   = Signal(intbv(0)[1:])
@@ -408,7 +390,7 @@ def test_binOps1c_convert():
     y   = Signal(False)
     z   = Signal(False)
 
-    i_dut = binOpsCheck(clk, a, b, c, x, y, z)
+    i_dut = binOpsCheck(a, b, c, x, y, z)
     assert i_dut.analyze_convert() == 0
     
 def test_binOps2():

--- a/myhdl/test/conversion/general/test_binops.py
+++ b/myhdl/test/conversion/general/test_binops.py
@@ -1,7 +1,7 @@
 from myhdl import *
 
 @block
-def binOpsCheck (
+def binOpsCheck0(
     a,
     b,
     c,
@@ -15,6 +15,36 @@ def binOpsCheck (
         x.next = a   
         y.next = a | b
         z.next = a | b | c
+
+    return instances()
+
+@block
+def binOpsCheck1(
+    a,
+    x,
+    y,
+    z,
+):
+   
+    @always_comb
+    def outputs():
+        x.next = a[0]   
+        y.next = a[0] | a[1]
+        z.next = a[0] | a[1] | a[2]
+
+    return instances()
+
+@block
+def binOpsCheck2(
+    a,
+    z,
+):
+   
+    @always_comb
+    def outputs():
+        z[0].next = a[0]   
+        z[1].next = a[0] | a[1]
+        z[2].next = a[0] | a[1] | a[2]
 
     return instances()
 
@@ -124,7 +154,7 @@ def binOpsCheckBench0():
         assert z == 0x0
         yield clk.posedge
    
-    i_binOpsCheck = binOpsCheck(a, b, c, x, y, z)
+    i_binOpsCheck = binOpsCheck0(a, b, c, x, y, z)
 
 
     return instances()
@@ -235,7 +265,7 @@ def binOpsCheckBench1():
         assert z == 0x0
         yield clk.posedge
    
-    i_binOpsCheck = binOpsCheck(a, b, c, x, y, z)
+    i_binOpsCheck = binOpsCheck0(a, b, c, x, y, z)
 
     return instances()
 
@@ -346,7 +376,7 @@ def binOpsCheckBench2():
         assert z == 0x0
         yield clk.posedge
    
-    i_binOpsCheck = binOpsCheck(a, b, c, x, y, z)
+    i_binOpsCheck = binOpsCheck0(a, b, c, x, y, z)
 
 
     return instances()
@@ -379,7 +409,7 @@ def test_binOps1b_convert():
     y   = Signal(False)
     z   = Signal(False)
 
-    i_dut = binOpsCheck(a, b, c, x, y, z)
+    i_dut = binOpsCheck0(a, b, c, x, y, z)
     assert i_dut.analyze_convert() == 0
  
 def test_binOps1c_convert():
@@ -390,7 +420,23 @@ def test_binOps1c_convert():
     y   = Signal(False)
     z   = Signal(False)
 
-    i_dut = binOpsCheck(a, b, c, x, y, z)
+    i_dut = binOpsCheck0(a, b, c, x, y, z)
+    assert i_dut.analyze_convert() == 0
+    
+def test_binOps1d_convert():
+    a   = Signal(intbv(0)[3:])
+    x   = Signal(False)
+    y   = Signal(False)
+    z   = Signal(False)
+
+    i_dut = binOpsCheck1(a, x, y, z)
+    assert i_dut.analyze_convert() == 0
+    
+def test_binOps1e_convert():
+    a   = Signal(intbv(0)[3:])
+    z   = Signal(intbv(0)[3:])
+
+    i_dut = binOpsCheck2(a, z)
     assert i_dut.analyze_convert() == 0
     
 def test_binOps2():
@@ -402,4 +448,3 @@ def test_binOps2_convert():
     assert i_dut.analyze_convert() == 0
     #assert i_dut.verify_convert() == 0
     #assert i_dut.verify_simulator() == 0
-    

--- a/myhdl/test/conversion/general/test_binops.py
+++ b/myhdl/test/conversion/general/test_binops.py
@@ -1,0 +1,423 @@
+from myhdl import *
+
+@block
+def binOpsCheck (
+    clk,
+    a,
+    b,
+    c,
+    x,
+    y,
+    z,
+):
+   
+    @always_comb
+    def outputs():
+        x.next = a   
+        y.next = a | b
+        z.next = a | b | c
+
+    return instances()
+
+# def maskedDataSetup():
+#     clk = Signal(bool(0)) 
+#     a   = Signal(modbv(0)[1:])
+#     b   = Signal(modbv(0)[1:])
+#     c   = Signal(modbv(0)[1:])
+#     x   = Signal(modbv(0)[1:])
+#     y   = Signal(modbv(0)[1:])
+#     z   = Signal(modbv(0)[1:])
+    
+#     i_maskedData = maskedData(clk, data_in, sel, data_out)
+#     return i_maskedData
+
+@block
+def binOpsCheckBench0():
+
+    clk = Signal(bool(0)) 
+    a   = Signal(modbv(0)[1:])
+    b   = Signal(modbv(0)[1:])
+    c   = Signal(modbv(0)[1:])
+    x   = Signal(modbv(0)[1:])
+    y   = Signal(modbv(0)[1:])
+    z   = Signal(modbv(0)[1:])
+    
+    @instance
+    def clkgen():
+        clk.next = 1
+        for i in range(400):
+            yield delay(10)
+            clk.next = not clk
+
+
+    
+    @instance
+    def stimulus():
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x1
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x1
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x1
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x0
+        c.next = 0x1
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x1
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x1
+        c.next = 0x1
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+
+        raise StopSimulation
+
+    @instance
+    def check():
+        yield clk.posedge
+        yield clk.posedge
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x0
+        assert z == 0x0
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x0
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x0
+        assert z == 0x0
+        yield clk.posedge
+   
+    i_binOpsCheck = binOpsCheck(clk, a, b, c, x, y, z)
+
+
+    return instances()
+
+@block
+def binOpsCheckBench1():
+
+    clk = Signal(bool(0)) 
+    a   = Signal(modbv(0)[1:])
+    b   = Signal(modbv(0)[1:])
+    c   = Signal(modbv(0)[1:])
+    x   = Signal(False)
+    y   = Signal(False)
+    z   = Signal(False)
+    
+    @instance
+    def clkgen():
+        clk.next = 1
+        for i in range(400):
+            yield delay(10)
+            clk.next = not clk
+    
+    @instance
+    def stimulus():
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x1
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x1
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x1
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x0
+        c.next = 0x1
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x1
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x1
+        c.next = 0x1
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+
+        raise StopSimulation
+
+    @instance
+    def check():
+        yield clk.posedge
+        yield clk.posedge
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x0
+        assert z == 0x0
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x0
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x0
+        assert z == 0x0
+        yield clk.posedge
+   
+    i_binOpsCheck = binOpsCheck(clk, a, b, c, x, y, z)
+
+
+    return instances()
+
+@block
+def binOpsCheckBench2():
+
+    clk = Signal(bool(0)) 
+    a   = Signal(modbv(0)[2:])
+    b   = Signal(modbv(0)[2:])
+    c   = Signal(modbv(0)[2:])
+    x   = Signal(modbv(0)[2:])
+    y   = Signal(modbv(0)[2:])
+    z   = Signal(modbv(0)[2:])
+    
+    @instance
+    def clkgen():
+        clk.next = 1
+        for i in range(400):
+            yield delay(10)
+            clk.next = not clk
+
+
+    @instance
+    def stimulus():
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x1
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x1
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x1
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x0
+        c.next = 0x1
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x1
+        c.next = 0x0
+        yield clk.posedge
+        a.next = 0x1
+        b.next = 0x1
+        c.next = 0x1
+        yield clk.posedge
+        a.next = 0x0
+        b.next = 0x0
+        c.next = 0x0
+        yield clk.posedge
+
+        raise StopSimulation
+
+    @instance
+    def check():
+        yield clk.posedge
+        yield clk.posedge
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x0
+        assert z == 0x0
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x0
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x1
+        assert y == 0x1
+        assert z == 0x1
+        yield clk.posedge
+        assert x == 0x0
+        assert y == 0x0
+        assert z == 0x0
+        yield clk.posedge
+   
+    i_binOpsCheck = binOpsCheck(clk, a, b, c, x, y, z)
+
+
+    return instances()
+
+
+def test_binOps0():
+    sim = binOpsCheckBench0()
+    sim.run_sim()
+
+def test_binOps0_convert():
+    i_dut = binOpsCheckBench0()
+    assert i_dut.analyze_convert() == 0
+    #assert i_dut.verify_simulator() == 0
+    #assert i_dut.verify_convert() == 0
+    
+def test_binOps1():
+    sim = binOpsCheckBench1()
+    sim.run_sim()
+
+def test_binOps1_convert():
+    i_dut = binOpsCheckBench1()
+    assert i_dut.analyze_convert() == 0
+    #assert i_dut.verify_simulator() == 0
+   
+def test_binOps1b_convert():
+    clk = Signal(bool(0)) 
+    a   = Signal(modbv(0)[1:])
+    b   = Signal(modbv(0)[1:])
+    c   = Signal(modbv(0)[1:])
+    x   = Signal(False)
+    y   = Signal(False)
+    z   = Signal(False)
+
+    i_dut = binOpsCheck(clk, a, b, c, x, y, z)
+    assert i_dut.analyze_convert() == 0
+ 
+def test_binOps1c_convert():
+    clk = Signal(bool(0)) 
+    a   = Signal(intbv(0)[1:])
+    b   = Signal(intbv(0)[1:])
+    c   = Signal(intbv(0)[1:])
+    x   = Signal(False)
+    y   = Signal(False)
+    z   = Signal(False)
+
+    i_dut = binOpsCheck(clk, a, b, c, x, y, z)
+    assert i_dut.analyze_convert() == 0
+    
+def test_binOps2():
+    sim = binOpsCheckBench2()
+    sim.run_sim()
+
+def test_binOps2_convert():
+    i_dut = binOpsCheckBench2()
+    assert i_dut.analyze_convert() == 0
+    #assert i_dut.verify_convert() == 0
+    #assert i_dut.verify_simulator() == 0
+    


### PR DESCRIPTION
This is the code fix to address issue #403.

The destination signal size and attribute was getting lost after one looped out of the first element in the lhs/rhs elements.  Now the parent ripples down the dest to all the children in the chain.