### PR TITLE
True case statment mapping support

### DIFF
--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1393,26 +1393,12 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.visit(node.subject)
         self.write(" is")
         self.indent()
-        baseobj  = self.getObj(node.subject)
         for i, c in enumerate(node.cases):
             self.writeline()
             self.write("when ")
-            if isinstance(c.pattern, ast.MatchValue):
-                item = c.pattern.value
-                obj = self.getObj(item)
-                
-                if isinstance(obj, EnumItemType):
-                    itemRepr = obj._toVHDL()
-                elif hasattr(baseobj, '_nrbits'):
-                    itemRepr = self.BitRepr(item.value, baseobj)
-                else:
-                    itemRepr = i
-                    raise
-                self.write(itemRepr)
-            elif isinstance(c.pattern, ast.MatchAs):
-                self.write("others")
-            else:
-                raise AssertionError("Unknown instance %s" % c.pattern)
+
+            c.pattern.subject = node.subject
+            self.visit(c.pattern)
 
             self.write(" => ")
             self.indent()
@@ -1425,7 +1411,52 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.dedent()
         self.writeline()
         self.write("end case;")
+ 
+    def visit_match_case(self, node):
+        raise AssertionError("Unsupported Match type %s " % (type(node)))
 
+    def visit_MatchValue(self, node):
+        baseobj  = self.getObj(node.subject)
+        item = node.value
+        obj = self.getObj(item)
+        
+        if isinstance(obj, EnumItemType):
+            itemRepr = obj._toVHDL()
+        elif hasattr(baseobj, '_nrbits'):
+            itemRepr = self.BitRepr(item.value, baseobj)
+        else:
+            raise AssertionError("Unknown type %s " % (type(obj)))
+        self.write(itemRepr)
+
+    def visit_MatchSingleton(self, node):
+        raise AssertionError("Unsupported Match type %s " % (type(node)))
+
+    def visit_MatchSequence(self, node):
+        raise AssertionError("Unsupported Match type %s " % (type(node)))
+
+    def visit_MatchStar(self, node):
+        raise AssertionError("Unsupported Match type %s " % (type(node)))
+
+    def visit_MatchMapping(self, node):
+        raise AssertionError("Unsupported Match type %s " % (type(node)))
+
+    def visit_MatchClass(self, node):
+        for i, pattern in enumerate(node.patterns):
+            pattern.subject = node.subject
+            self.visit(pattern)
+
+    def visit_MatchAs(self, node):
+        if node.name is None and  node.pattern is None:
+            self.write("others")
+        else:
+            raise AssertionError("Unknown name %s or pattern %s" % (node.name, node.pattern))
+    
+    def visit_MatchOr(self, node):
+        for i, pattern in enumerate(node.patterns):
+            pattern.subject = node.subject
+            self.visit(pattern)
+            if not i == len(node.patterns)-1:
+                self.write(" | ")
 
     def mapToCase(self, node):
         var = node.caseVar

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1393,7 +1393,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.visit(node.subject)
         self.write(" is")
         self.indent()
-        for i, c in enumerate(node.cases):
+        for c in node.cases:
             self.writeline()
             self.write("when ")
 

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1388,32 +1388,40 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         else:
             self.mapToIf(node)
 
+    def visit_Cases(self, node):
+        raise
+    
+    # def visit_Case(self, node):
+    #     raise
+    
     def visit_Match(self, node):
         self.write("case ")
         self.visit(node.subject)
         self.write(" is")
         self.indent()
         for c in node.cases:
-            self.writeline()
-            self.write("when ")
-
-            c.pattern.subject = node.subject
-            self.visit(c.pattern)
-
-            self.write(" => ")
-            self.indent()
-            # Write all the multiple assignment per case
-            for b in c.body:
-                self.writeline()
-                self.visit(b)
-            self.dedent()
+            c.subject = node.subject
+            self.visit(c)
 
         self.dedent()
         self.writeline()
         self.write("end case;")
  
     def visit_match_case(self, node):
-        raise AssertionError("Unsupported Match type %s " % (type(node)))
+        self.writeline()
+        self.write("when ")
+
+        pattern = node.pattern
+        pattern.subject = node.subject
+        self.visit(pattern)
+
+        self.write(" => ")
+        self.indent()
+        # Write all the multiple assignment per case
+        for b in node.body:
+            self.writeline()
+            self.visit(b)
+        self.dedent()
 
     def visit_MatchValue(self, node):
         baseobj  = self.getObj(node.subject)

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1393,17 +1393,18 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.visit(node.subject)
         self.write(" is")
         self.indent()
+        baseobj  = self.getObj(node.subject)
         for i, c in enumerate(node.cases):
             self.writeline()
             self.write("when ")
             if isinstance(c.pattern, ast.MatchValue):
                 item = c.pattern.value
-                obj = self.getObj(node.subject)
+                obj = self.getObj(item)
                 
-                if isinstance(item, EnumItemType):
-                    itemRepr = item._toVHDL()
-                elif hasattr(obj, '_nrbits'):
-                    itemRepr = self.BitRepr(item.value, obj)
+                if isinstance(obj, EnumItemType):
+                    itemRepr = obj._toVHDL()
+                elif hasattr(baseobj, '_nrbits'):
+                    itemRepr = self.BitRepr(item.value, baseobj)
                 else:
                     itemRepr = i
                     raise

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1441,7 +1441,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         raise AssertionError("Unsupported Match type %s " % (type(node)))
 
     def visit_MatchClass(self, node):
-        for i, pattern in enumerate(node.patterns):
+        for pattern in node.patterns:
             pattern.subject = node.subject
             self.visit(pattern)
 

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1387,12 +1387,6 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             self.mapToCase(node)
         else:
             self.mapToIf(node)
-
-    def visit_Cases(self, node):
-        raise
-    
-    # def visit_Case(self, node):
-    #     raise
     
     def visit_Match(self, node):
         self.write("case ")

--- a/myhdl/conversion/_toVHDL.py
+++ b/myhdl/conversion/_toVHDL.py
@@ -1393,9 +1393,9 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.visit(node.subject)
         self.write(" is")
         self.indent()
-        for c in node.cases:
-            c.subject = node.subject
-            self.visit(c)
+        for case in node.cases:
+            case.subject = node.subject
+            self.visit(case)
 
         self.dedent()
         self.writeline()
@@ -1412,9 +1412,9 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.write(" => ")
         self.indent()
         # Write all the multiple assignment per case
-        for b in node.body:
+        for stmt in node.body:
             self.writeline()
-            self.visit(b)
+            self.visit(stmt)
         self.dedent()
 
     def visit_MatchValue(self, node):

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -1038,23 +1038,9 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.visit(node.subject)
         self.write(")")
         self.indent()
-        for c in node.cases:
-            c.subject = node.subject
-            self.visit(c)
+        for case in node.cases:
+            self.visit(case)
             self.writeline()
-
-            # c.pattern.subject = node.subject
-            # self.visit(c.pattern)
-
-            # self.write(": begin ")
-            # self.indent()
-            # # Write all the multiple assignment per case
-            # for b in c.body:
-            #     self.writeline()
-            #     self.visit(b)
-            # self.dedent()
-            # self.writeline()
-            # self.write("end")
 
         self.dedent()
         self.writeline()
@@ -1062,15 +1048,14 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
 
     def visit_match_case(self, node):
         pattern = node.pattern
-        pattern.subject = node.subject
         self.visit(pattern)
 
         self.write(": begin ")
         self.indent()
         # Write all the multiple assignment per case
-        for b in node.body:
+        for stmt in node.body:
             self.writeline()
-            self.visit(b)
+            self.visit(stmt)
         self.dedent()
         self.writeline()
         self.write("end")
@@ -1100,7 +1085,6 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
 
     def visit_MatchClass(self, node):
         for pattern in node.patterns:
-            #pattern.subject = node.subject
             self.visit(pattern)
 
     def visit_MatchAs(self, node):
@@ -1111,7 +1095,6 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
     
     def visit_MatchOr(self, node):
         for i, pattern in enumerate(node.patterns):
-            pattern.subject = node.subject
             self.visit(pattern)
             if not i == len(node.patterns)-1:
                 self.write(" | ")

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -1100,7 +1100,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
 
     def visit_MatchClass(self, node):
         for pattern in node.patterns:
-            pattern.subject = node.subject
+            #pattern.subject = node.subject
             self.visit(pattern)
 
     def visit_MatchAs(self, node):

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -1039,27 +1039,41 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         self.write(")")
         self.indent()
         for c in node.cases:
+            c.subject = node.subject
+            self.visit(c)
             self.writeline()
 
-            c.pattern.subject = node.subject
-            self.visit(c.pattern)
+            # c.pattern.subject = node.subject
+            # self.visit(c.pattern)
 
-            self.write(": begin ")
-            self.indent()
-            # Write all the multiple assignment per case
-            for b in c.body:
-                self.writeline()
-                self.visit(b)
-            self.dedent()
-            self.writeline()
-            self.write("end")
+            # self.write(": begin ")
+            # self.indent()
+            # # Write all the multiple assignment per case
+            # for b in c.body:
+            #     self.writeline()
+            #     self.visit(b)
+            # self.dedent()
+            # self.writeline()
+            # self.write("end")
 
         self.dedent()
         self.writeline()
         self.write("endcase")
 
     def visit_match_case(self, node):
-        raise AssertionError("Unsupported Match type %s " % (type(node)))
+        pattern = node.pattern
+        pattern.subject = node.subject
+        self.visit(pattern)
+
+        self.write(": begin ")
+        self.indent()
+        # Write all the multiple assignment per case
+        for b in node.body:
+            self.writeline()
+            self.visit(b)
+        self.dedent()
+        self.writeline()
+        self.write("end")
 
     def visit_MatchValue(self, node):
         item = node.value

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -1085,7 +1085,7 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
         raise AssertionError("Unsupported Match type %s " % (type(node)))
 
     def visit_MatchClass(self, node):
-        for i, pattern in enumerate(node.patterns):
+        for pattern in node.patterns:
             pattern.subject = node.subject
             self.visit(pattern)
 

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -1042,8 +1042,10 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             self.writeline()
             if isinstance(c.pattern, ast.MatchValue):
                 item = c.pattern.value
-                if isinstance(item, EnumItemType):
-                    itemRepr = item._toVerilog()
+                obj = self.getObj(item)
+
+                if isinstance(obj, EnumItemType):
+                    itemRepr = obj._toVerilog()
                 else:
                     itemRepr = self.IntRepr(item.value, radix='hex')
                 self.write(itemRepr)

--- a/myhdl/test/conversion/general/test_match.py
+++ b/myhdl/test/conversion/general/test_match.py
@@ -1,0 +1,142 @@
+from myhdl import *
+
+@block
+def mux4a(
+    sel, 
+    in0, 
+    in1, 
+    in2, 
+    in3, 
+    out0
+):
+    
+    @always_comb
+    def rtl():
+        if sel == 0:
+            out0.next = in0
+        elif sel == 1:
+            out0.next = in1
+        elif sel == 2:
+            out0.next = in2
+        else:
+            out0.next = in3
+
+    return instances()
+
+@block
+def mux4b(sel, in0, in1, in2, in3, out0):
+    @always_comb
+    def rtl():
+        match sel:
+            case 0:
+                out0.next = in0
+            case 1:
+                out0.next = in1
+            case 2:
+                out0.next = in2
+            case _:
+                out0.next = in3
+
+    return instances()
+
+@block
+def muxBench0(setup=0):
+
+    clk  = Signal(bool(0)) 
+    sel  = Signal(intbv(0)[2:])
+    in0  = Signal(intbv(0)[4:]) 
+    in1  = Signal(intbv(0)[4:]) 
+    in2  = Signal(intbv(0)[4:]) 
+    in3  = Signal(intbv(0)[4:]) 
+    out0 = Signal(intbv(0)[4:]) 
+    
+    @instance
+    def clkgen():
+        clk.next = 1
+        for i in range(400):
+            yield delay(10)
+            clk.next = not clk
+
+    @instance
+    def stimulus():
+        sel.next = 0x0
+        in0.next = 0xa
+        in1.next = 0xb
+        in2.next = 0xc
+        in3.next = 0xd
+        yield clk.posedge
+        yield clk.posedge
+        sel.next = 0x1
+        yield clk.posedge
+        sel.next = 0x2
+        yield clk.posedge
+        sel.next = 0x3
+        yield clk.posedge
+        sel.next = 0x0
+        yield clk.posedge
+
+        raise StopSimulation
+
+    @instance
+    def check():
+        yield clk.posedge
+        yield clk.posedge
+        assert out0 == 0xa
+        yield clk.posedge
+        assert out0 == 0xb
+        yield clk.posedge
+        assert out0 == 0xc
+        yield clk.posedge
+        assert out0 == 0xd
+        yield clk.posedge
+        assert out0 == 0xa
+        yield clk.posedge
+   
+    if 0 == setup:
+        i_mux = mux4a(sel, in0, in1, in2, in3, out0)
+    else:
+        i_mux = mux4b(sel, in0, in1, in2, in3, out0)
+
+    return instances()
+
+def test_mux4a_convert():
+    clk  = Signal(bool(0)) 
+    sel  = Signal(intbv(0)[2:])
+    in0  = Signal(intbv(0)[4:]) 
+    in1  = Signal(intbv(0)[4:]) 
+    in2  = Signal(intbv(0)[4:]) 
+    in3  = Signal(intbv(0)[4:]) 
+    out0 = Signal(intbv(0)[4:]) 
+
+    i_dut = mux4a(sel, in0, in1, in2, in3, out0)
+    assert i_dut.analyze_convert() == 0
+
+def test_muxBench0():
+    sim = muxBench0(0)
+    sim.run_sim()
+    
+def test_muxBench0_convert():
+    i_dut = muxBench0(0)
+    assert i_dut.analyze_convert() == 0
+
+def test_mux4b_convert():
+    clk  = Signal(bool(0)) 
+    sel  = Signal(intbv(0)[2:])
+    in0  = Signal(intbv(0)[4:]) 
+    in1  = Signal(intbv(0)[4:]) 
+    in2  = Signal(intbv(0)[4:]) 
+    in3  = Signal(intbv(0)[4:]) 
+    out0 = Signal(intbv(0)[4:]) 
+
+    i_dut = mux4b(sel, in0, in1, in2, in3, out0)
+    assert i_dut.analyze_convert() == 0
+
+def test_muxBench1():
+    sim = muxBench0(1)
+    sim.run_sim()
+
+def test_muxBench1_convert():
+    i_dut = muxBench0(1)
+    assert i_dut.analyze_convert() == 0
+
+

--- a/myhdl/test/conversion/general/test_match_py310.py
+++ b/myhdl/test/conversion/general/test_match_py310.py
@@ -42,6 +42,19 @@ def mux4b(sel, in0, in1, in2, in3, out0):
                 out0.next = in3
     return instances()
 
+@block
+def mux4c(sel, in0, in1, in3, out0):
+    @always_comb
+    def rtl():
+        match sel:
+            case 0:
+                out0.next = in0
+            case 1 | 2:
+                out0.next = in1
+            case _:
+                out0.next = in3
+    return instances()
+
 t_opts = enum('SEL0', 'SEL1', 'SEL2', 'SEL3')
 
 @block
@@ -115,6 +128,60 @@ def enumMux4b(
                 out0.next = in2
             case _:
                 out0.next = in3        
+
+    return instances()
+
+t_fsma_opts = enum('IDLE', 'READ', 'WRITE', 'ERROR')
+
+@block
+def fsm4a(
+    clk, 
+    rst, 
+    rd, 
+    wr, 
+):
+    smp = Signal(t_fsma_opts.IDLE)
+    
+    @always(clk.posedge)
+    def rtl():
+        
+        if rst:
+            smp.next =  t_fsma_opts.IDLE
+        else:
+            match smp:
+                case t_fsma_opts.IDLE:
+                    smp.next =  t_fsma_opts.IDLE
+                    if rd:
+                        smp.next =  t_fsma_opts.READ
+                    if wr:
+                        smp.next =  t_fsma_opts.WRITE
+                case t_fsma_opts.READ:
+                    smp.next =  t_fsma_opts.IDLE
+                case t_fsma_opts.WRITE:
+                    smp.next =  t_fsma_opts.IDLE
+                case _:
+                    smp.next =  t_fsma_opts.IDLE
+
+    return instances()
+
+@block
+def fsm4b(
+    clk, 
+    a, 
+    b, 
+    c, 
+    z, 
+):
+    
+    @always(clk.posedge)
+    def rtl():
+        match concat(a,b,c):
+            case intbv(0b111) :
+                z.next = 0x6
+            case intbv(0b101) | intbv(0b110) :
+                z.next = 0x7
+            case _:
+                z.next = 0x0
 
     return instances()
 
@@ -204,7 +271,7 @@ def test_muxBench0_convert():
     i_dut = muxBench0(0)
     assert i_dut.analyze_convert() == 0
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
+#@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_mux4b_convert():
     clk  = Signal(bool(0)) 
     sel  = Signal(intbv(0)[2:])
@@ -217,12 +284,24 @@ def test_mux4b_convert():
     i_dut = mux4b(sel, in0, in1, in2, in3, out0)
     assert i_dut.analyze_convert() == 0
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
+#@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
+def test_mux4b_convert():
+    clk  = Signal(bool(0)) 
+    sel  = Signal(intbv(0)[2:])
+    in0  = Signal(intbv(0)[4:]) 
+    in1  = Signal(intbv(0)[4:]) 
+    in3  = Signal(intbv(0)[4:]) 
+    out0 = Signal(intbv(0)[4:]) 
+
+    i_dut = mux4c(sel, in0, in1, in3, out0)
+    assert i_dut.analyze_convert() == 0
+
+#@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_muxBench1():
     sim = muxBench0(1)
     sim.run_sim()
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
+#@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_muxBench1_convert():
     i_dut = muxBench0(1)
     assert i_dut.analyze_convert() == 0
@@ -261,5 +340,27 @@ def test_enumMux4b_convert():
     out0 = Signal(intbv(0)[4:]) 
 
     i_dut = enumMux4b(sel, in0, in1, in2, in3, out0)
+    assert i_dut.analyze_convert() == 0
+
+
+def test_fsm4a_convert():
+    clk = Signal(bool(0)) 
+    rst = Signal(intbv(0)[1:]) 
+    rd  = Signal(intbv(0)[1:]) 
+    wr  = Signal(intbv(0)[1:]) 
+
+
+    i_dut = fsm4a(clk, rst, rd, wr)
+    assert i_dut.analyze_convert() == 0
+
+def test_fsm4b_convert():
+    clk = Signal(bool(0)) 
+    a   = Signal(intbv(0)[1:]) 
+    b   = Signal(intbv(0)[1:]) 
+    c   = Signal(intbv(0)[1:]) 
+    z   = Signal(intbv(0)[3:])
+
+
+    i_dut = fsm4b(clk, a, b, c, z)
     assert i_dut.analyze_convert() == 0
 

--- a/myhdl/test/conversion/general/test_match_py310.py
+++ b/myhdl/test/conversion/general/test_match_py310.py
@@ -1,4 +1,6 @@
+import sys
 from myhdl import *
+import pytest
 
 @block
 def mux4a(
@@ -27,16 +29,16 @@ def mux4a(
 def mux4b(sel, in0, in1, in2, in3, out0):
     @always_comb
     def rtl():
-        match sel:
-            case 0:
-                out0.next = in0
-            case 1:
-                out0.next = in1
-            case 2:
-                out0.next = in2
-            case _:
-                out0.next = in3
-
+            pass
+            match sel:
+                case 0:
+                    out0.next = in0
+                case 1:
+                    out0.next = in1
+                case 2:
+                    out0.next = in2
+                case _:
+                    out0.next = in3
     return instances()
 
 @block
@@ -119,6 +121,7 @@ def test_muxBench0_convert():
     i_dut = muxBench0(0)
     assert i_dut.analyze_convert() == 0
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_mux4b_convert():
     clk  = Signal(bool(0)) 
     sel  = Signal(intbv(0)[2:])
@@ -131,10 +134,12 @@ def test_mux4b_convert():
     i_dut = mux4b(sel, in0, in1, in2, in3, out0)
     assert i_dut.analyze_convert() == 0
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_muxBench1():
     sim = muxBench0(1)
     sim.run_sim()
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_muxBench1_convert():
     i_dut = muxBench0(1)
     assert i_dut.analyze_convert() == 0

--- a/myhdl/test/conversion/general/test_match_py310.py
+++ b/myhdl/test/conversion/general/test_match_py310.py
@@ -2,6 +2,8 @@ import sys
 from myhdl import *
 import pytest
 
+#SELOPTS = enum('SEL0', 'SEL1', 'SEL2', 'SEL3')
+
 @block
 def mux4a(
     sel, 
@@ -29,17 +31,94 @@ def mux4a(
 def mux4b(sel, in0, in1, in2, in3, out0):
     @always_comb
     def rtl():
-            pass
-            match sel:
-                case 0:
-                    out0.next = in0
-                case 1:
-                    out0.next = in1
-                case 2:
-                    out0.next = in2
-                case _:
-                    out0.next = in3
+        match sel:
+            case 0:
+                out0.next = in0
+            case 1:
+                out0.next = in1
+            case 2:
+                out0.next = in2
+            case _:
+                out0.next = in3
     return instances()
+
+t_opts = enum('SEL0', 'SEL1', 'SEL2', 'SEL3')
+
+@block
+def enumMux4a(
+    sel, 
+    in0, 
+    in1, 
+    in2, 
+    in3, 
+    out0,
+):
+    
+    sel_enum = Signal(t_opts.SEL0)
+    
+    @always_comb
+    def mapping():
+        if 0 == sel:
+            sel_enum.next = t_opts.SEL0
+        elif 1 == sel:
+            sel_enum.next = t_opts.SEL1
+        elif 2 == sel:
+            sel_enum.next = t_opts.SEL2
+        elif 3 == sel:
+            sel_enum.next = t_opts.SEL3
+    
+    
+    @always_comb
+    def rtl():
+        if sel_enum == t_opts.SEL0:
+            out0.next = in0
+        elif sel_enum == t_opts.SEL1:
+            out0.next = in1
+        elif sel_enum == t_opts.SEL2:
+            out0.next = in2
+        elif sel_enum == t_opts.SEL3:
+            out0.next = in3
+
+    return instances()
+
+@block
+def enumMux4b(
+    sel, 
+    in0, 
+    in1, 
+    in2, 
+    in3, 
+    out0,
+):
+    sel_enum = Signal(t_opts.SEL0)
+    
+    @always_comb
+    def mapping():
+        if 0 == sel:
+            sel_enum.next = t_opts.SEL0
+        elif 1 == sel:
+            sel_enum.next = t_opts.SEL1
+        elif 2 == sel:
+            sel_enum.next = t_opts.SEL2
+        elif 3 == sel:
+            sel_enum.next = t_opts.SEL3
+    
+    
+    @always_comb
+    def rtl():
+        match sel_enum:
+            case t_opts.SEL0:
+                out0.next = in0
+            case t_opts.SEL1:
+                out0.next = in1
+            case t_opts.SEL2:
+                out0.next = in2
+            case _:
+                out0.next = in3        
+
+    return instances()
+
+
 
 @block
 def muxBench0(setup=0):
@@ -96,8 +175,12 @@ def muxBench0(setup=0):
    
     if 0 == setup:
         i_mux = mux4a(sel, in0, in1, in2, in3, out0)
-    else:
+    elif 1 == setup:
         i_mux = mux4b(sel, in0, in1, in2, in3, out0)
+    elif 2 == setup:
+        i_mux = enumMux4a(sel, in0, in1, in2, in3, out0)
+    else:
+        i_mux = enumMux4b(sel, in0, in1, in2, in3, out0)
 
     return instances()
 
@@ -144,4 +227,39 @@ def test_muxBench1_convert():
     i_dut = muxBench0(1)
     assert i_dut.analyze_convert() == 0
 
+def test_muxBench2():
+    sim = muxBench0(2)
+    sim.run_sim()
+
+def test_muxBench2_convert():
+    i_dut = muxBench0(2)
+    assert i_dut.analyze_convert() == 0
+
+def test_enumMux4a_convert():
+    clk  = Signal(bool(0)) 
+    sel  = Signal(intbv(0)[2:])
+    in0  = Signal(intbv(0)[4:]) 
+    in1  = Signal(intbv(0)[4:]) 
+    in2  = Signal(intbv(0)[4:]) 
+    in3  = Signal(intbv(0)[4:]) 
+    out0 = Signal(intbv(0)[4:]) 
+
+    i_dut = enumMux4a(sel, in0, in1, in2, in3, out0)
+    assert i_dut.analyze_convert() == 0
+
+def test_muxBench3():
+    sim = muxBench0(3)
+    sim.run_sim()
+
+def test_enumMux4b_convert():
+    clk  = Signal(bool(0)) 
+    sel  = Signal(intbv(0)[2:])
+    in0  = Signal(intbv(0)[4:]) 
+    in1  = Signal(intbv(0)[4:]) 
+    in2  = Signal(intbv(0)[4:]) 
+    in3  = Signal(intbv(0)[4:]) 
+    out0 = Signal(intbv(0)[4:]) 
+
+    i_dut = enumMux4b(sel, in0, in1, in2, in3, out0)
+    assert i_dut.analyze_convert() == 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
+pytest-xdist
 pyflakes
 black


### PR DESCRIPTION
I have had a look at this issue, #386.  (This is an excellent issue to help one learn how the python ast works).

This works for all the conditions listed in the, basic conditional, enumerated type and concats.

This is a wholly constructive addition, it does not change any testing for code that doesn't use the python `match` keyword.  The cases where a fully populated if statement results in a `case` statement in RTL still works like that, but one should consider migrating away from that in future releases, as this is a much more important feature in RTL land (and @josyb has a preference for mapping the programmers intent with implementation [#405](https://github.com/myhdl/myhdl/issues/405#issuecomment-1397474009)

