### PR TITLE
Add windows actions, python3.11 for core and ghdl

### DIFF
--- a/.github/workflows/test_checkin.yml
+++ b/.github/workflows/test_checkin.yml
@@ -29,15 +29,14 @@ jobs:
     #uses: daxzio/setup-eda/.github/workflows/setup_iverilog.yml@main
     uses: ./.github/workflows/setup_iverilog.yml
 
-  build_code:
+  build_code_linux:
 
     strategy:
       fail-fast: false # So that one fail doesn't stop remaining tests
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.9", "3.11"]
-        os: [ubuntu-latest]
         target: [core, iverilog, ghdl]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     needs: [run_lint, build_ghdl, build_iverilog]
 
     env:
@@ -46,6 +45,9 @@ jobs:
     
     steps:
       - uses: actions/checkout@v3
+      - name: Report Environment
+        run: |
+          echo "Runing tests with env set to : ${CI_TARGET}"
       - name: Cache GHDL
         uses: actions/cache@v3
         with:
@@ -64,14 +66,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade -r requirements.txt
           python -m pip install .
-      - name: Report Environment
-        run: |
-          echo "Runing tests with env set to : ${CI_TARGET}"
       - name: Install depenacy for ghdl
         if: ${{ env.CI_TARGET == 'ghdl' }}
         run: |
@@ -80,10 +80,70 @@ jobs:
         run: |
           make ${CI_TARGET}
   
+  build_code_windows:
+
+    strategy:
+      fail-fast: false # So that one fail doesn't stop remaining tests
+      matrix:
+        python-version: ["3.11"]
+        #target: [core, iverilog, ghdl]
+        target: [core, ghdl]
+    runs-on: windows-latest
+    defaults:
+      run:
+       shell: msys2 {0}
+    needs: [run_lint]
+
+    env:
+      CI_TARGET: ${{ matrix.target }}
+    
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          path-type: inherit
+          update: true
+          pacboy: >-
+            make:p
+      - name: Report Environment
+        run: |
+          echo "Runing tests with env set to : ${{ env.CI_TARGET }}"
+        
+      - if: ${{ env.CI_TARGET == 'ghdl' }}
+        uses: ghdl/setup-ghdl-ci@nightly
+        with:
+          backend: llvm
+      - if: ${{ env.CI_TARGET == 'iverilog' }}
+        name: Choco iverilog
+        run: |
+          choco install --yes ${{ env.CI_TARGET }}
+      - if: ${{ env.CI_TARGET == 'iverilog' }}
+        name: Compile vpi
+        run: |
+          make iverilog_myhdl.vpi
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Set environment variables
+        run: |
+          echo "${{ env.pythonLocation }}\bin" >> $GITHUB_PATH
+          echo "C:\ProgramData\Chocolatey\bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade -r requirements.txt
+          python -m pip install .
+      - name: Run Tests
+        run: |
+          make ${{ env.CI_TARGET }}
+  
   pypy_release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
-    needs: [build_code]
+    needs: [build_code_linux, build_code_windows]
     steps:
       - uses: actions/checkout@v3
       - name: Make PyPi dist release

--- a/.github/workflows/test_checkin.yml
+++ b/.github/workflows/test_checkin.yml
@@ -22,10 +22,10 @@ jobs:
         run: |
           pyflakes myhdl
  
-  build_ghdl:
+  build_ghdl_linux:
     #uses: daxzio/setup-eda/.github/workflows/setup_ghdl.yml@main
     uses: ./.github/workflows/setup_ghdl.yml
-  build_iverilog:
+  build_iverilog_linux:
     #uses: daxzio/setup-eda/.github/workflows/setup_iverilog.yml@main
     uses: ./.github/workflows/setup_iverilog.yml
 
@@ -37,7 +37,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.9", "3.11"]
         target: [core, iverilog, ghdl]
     runs-on: ubuntu-latest
-    needs: [run_lint, build_ghdl, build_iverilog]
+    needs: [run_lint, build_ghdl_linux, build_iverilog_linux]
 
     env:
       CI_TARGET: ${{ matrix.target }}

--- a/.github/workflows/test_checkin.yml
+++ b/.github/workflows/test_checkin.yml
@@ -51,17 +51,17 @@ jobs:
       - name: Cache GHDL
         uses: actions/cache@v3
         with:
-          path: ${{ needs.build_ghdl.outputs.cache_dir }}
-          key: ${{ needs.build_ghdl.outputs.cache_key }}
+          path: ${{ needs.build_ghdl_linux.outputs.cache_dir }}
+          key: ${{ needs.build_ghdl_linux.outputs.cache_key }}
       - name: Cache Icarus
         uses: actions/cache@v3
         with:
-          path: ${{ needs.build_iverilog.outputs.cache_dir }}
-          key: ${{ needs.build_iverilog.outputs.cache_key }}
+          path: ${{ needs.build_iverilog_linux.outputs.cache_dir }}
+          key: ${{ needs.build_iverilog_linux.outputs.cache_key }}
       - name: Add to PATH
         run: |
-          echo "${{ needs.build_ghdl.outputs.cache_dir }}/bin" >> $GITHUB_PATH
-          echo "${{ needs.build_iverilog.outputs.cache_dir }}/bin" >> $GITHUB_PATH
+          echo "${{ needs.build_ghdl_linux.outputs.cache_dir }}/bin" >> $GITHUB_PATH
+          echo "${{ needs.build_iverilog_linux.outputs.cache_dir }}/bin" >> $GITHUB_PATH
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
I have added initial support for windows on githib actions.  I was able to get the core and ghdl runs to work.  There is still some work to do on iverilog, but I think it is worth while taking this merge and seeing how it goes.