### PR TITLE
**Constant** signals

### DIFF
--- a/myhdl/_Signal.py
+++ b/myhdl/_Signal.py
@@ -180,8 +180,8 @@ class _Signal(object):
         self._val = deepcopy(self._init)
         self._next = deepcopy(self._init)
         self._name = self._driven = None
-        self._read = False # dont clear self._used
-        self._inList = False 
+        self._read = False  # dont clear self._used
+        self._inList = False
         self._numeric = True
         for s in self._slicesigs:
             s._clear()
@@ -268,7 +268,7 @@ class _Signal(object):
 
     @read.setter
     def read(self, val):
-        if not val in (True, ):
+        if not val in (True,):
             raise ValueError('Expected value True, got "%s"' % val)
         self._markRead()
 
@@ -552,7 +552,7 @@ class _Signal(object):
     def __setitem__(self, key, val):
         raise TypeError("Signal object doesn't support item/slice assignment")
 
-    # continues assignment support
+    # continuous assignment support
     def assign(self, sig):
 
         self.driven = "wire"
@@ -636,6 +636,38 @@ class _SignalWrap(object):
 
     def apply(self):
         return self.sig._apply(self.next, self.timeStamp)
+
+
+class Constant(_Signal):
+    ''' effective constants '''
+
+    def __init__(self, val=None):
+        super(Constant, self).__init__(val)
+
+    # override some essentials
+    def __repr__(self):
+        return "Constant(" + repr(self._val) + ")"
+
+    # there is support for the 'next' attribute
+    @property
+    def next(self):
+        return None
+
+    @next.setter
+    def next(self, val):
+        raise PermissionError("A 'Constant' can not be changed!")
+
+    # neither can it be driven
+    # support for the 'driven' attribute
+    @property
+    def driven(self):
+        return None
+
+    @driven.setter
+    def driven(self, val):
+        # quietly ignore?
+        pass
+
 
 # for export
 SignalType = _Signal

--- a/myhdl/__init__.py
+++ b/myhdl/__init__.py
@@ -49,7 +49,7 @@ traceSignals -- function that enables signal tracing in a VCD file
 toVerilog -- function that converts a design to Verilog
 
 """
-__version__ = "0.11.42"
+__version__ = "0.11.43"
 
 
 class StopSimulation(Exception):
@@ -139,7 +139,7 @@ class ToVHDLWarning(ConversionWarning):
 # def showwarning(message, category, filename, lineno, *args):
 #    print("** %s: %s" % (category.__name__, message), file=sys.stderr)
 
-#warnings.showwarning = showwarning
+# warnings.showwarning = showwarning
 
 
 from ._bin import bin
@@ -147,7 +147,7 @@ from ._concat import concat
 from ._intbv import intbv
 from ._modbv import modbv
 from ._join import join
-from ._Signal import posedge, negedge, Signal, SignalType
+from ._Signal import posedge, negedge, Signal, SignalType, Constant
 from ._ShadowSignal import ConcatSignal
 from ._ShadowSignal import TristateSignal
 from ._simulator import now
@@ -169,7 +169,6 @@ from .conversion import toVHDL
 
 from ._tristate import Tristate
 
-
 __all__ = ["bin",
            "concat",
            "intbv",
@@ -179,6 +178,7 @@ __all__ = ["bin",
            "negedge",
            "Signal",
            "SignalType",
+           "Constant",
            "ConcatSignal",
            "TristateSignal",
            "now",

--- a/myhdl/_always_comb.py
+++ b/myhdl/_always_comb.py
@@ -21,7 +21,7 @@
 from types import FunctionType
 
 from myhdl import AlwaysCombError
-from myhdl._Signal import _Signal, _isListOfSigs
+from myhdl._Signal import _Signal, _isListOfSigs, Constant
 from myhdl._util import _isGenFunc
 from myhdl._instance import _getCallInfo
 from myhdl._always import _Always
@@ -62,9 +62,9 @@ class _AlwaysComb(_Always):
 
         for n in self.inputs:
             s = self.symdict[n]
-            if isinstance(s, _Signal):
+            if isinstance(s, _Signal) and not isinstance(s, Constant):
                 senslist.append(s)
-            elif _isListOfSigs(s):
+            elif _isListOfSigs(s) and not isinstance(s[0], Constant):
                 senslist.extend(s)
         self.senslist = tuple(senslist)
         if len(self.senslist) == 0:
@@ -79,4 +79,3 @@ class _AlwaysComb(_Always):
             func()
             yield senslist
 
-            

--- a/myhdl/conversion/_toVHDLPackage.py
+++ b/myhdl/conversion/_toVHDLPackage.py
@@ -19,8 +19,8 @@
 
 import myhdl
 
-_version = myhdl.__version__.replace('.', '')[:-2]
-_shortversion = _version.replace('dev', '')
+_version = myhdl.__version__.replace('.', '')
+_shortversion = _version.replace('dev', '')[:-2]
 
 _package = """\
 library ieee;

--- a/myhdl/conversion/_toVHDLPackage.py
+++ b/myhdl/conversion/_toVHDLPackage.py
@@ -19,7 +19,7 @@
 
 import myhdl
 
-_version = myhdl.__version__.replace('.', '')
+_version = myhdl.__version__.replace('.', '')[:-2]
 _shortversion = _version.replace('dev', '')
 
 _package = """\
@@ -191,4 +191,4 @@ package body pck_myhdl_%(version)s is
 
 end pck_myhdl_%(version)s;
 
-""" % {'version' : _shortversion}
+""" % {'version': _shortversion}

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -45,7 +45,7 @@ from myhdl.conversion._misc import (_error, _kind, _context,
                                     _ConversionMixin, _Label, _genUniqueSuffix, _isConstant)
 from myhdl.conversion._analyze import (_analyzeSigs, _analyzeGens, _analyzeTopFunc,
                                        _Ram, _Rom)
-from myhdl._Signal import _Signal
+from myhdl._Signal import _Signal, Constant
 from myhdl._ShadowSignal import _TristateSignal, _TristateDriver
 
 from myhdl._block import _Block
@@ -340,14 +340,20 @@ def _writeSigDecls(f, intf, siglist, memlist):
                     print("%s %s%s%s = %s;" %
                           (k, p, r, s._name, _intRepr(s._init)), file=f)
         elif s._read:
-            # the original exception
-            # raise ToVerilogError(_error.UndrivenSignal, s._name)
-            # changed to a warning and a continuous assignment to a wire
-            warnings.warn("%s: %s" % (_error.UndrivenSignal, s._name),
-                          category=ToVerilogWarning
-                          )
-            constwires.append(s)
-            print("wire %s%s;" % (r, s._name), file=f)
+            if isinstance(s, Constant):
+                c = int(s.val)
+                c_len = s._nrbits
+                c_str = "%s" % c
+                print("localparam %s%s = %s'd%s;" % (r, s._name, c_len, c_str), file=f)
+            else:
+                # the original exception
+                # raise ToVerilogError(_error.UndrivenSignal, s._name)
+                # changed to a warning and a continuous assignment to a wire
+                warnings.warn("%s: %s" % (_error.UndrivenSignal, s._name),
+                              category=ToVerilogWarning
+                              )
+                constwires.append(s)
+                print("wire %s%s;" % (r, s._name), file=f)
     # print(file=f)
     for m in memlist:
         if not m._used:
@@ -392,9 +398,16 @@ def _writeSigDecls(f, intf, siglist, memlist):
                          for n, each in enumerate(m.mem)])
                     initial_assignments = (
                         'initial begin\n' + val_assignments + '\nend')
+            print("%s %s%s%s [0:%s-1];" % (k, p, r, m.name, m.depth), file=f)
+        else:
+            # can assume it is a localparam array
+            # build the initial values list
+            vals = []
+            w = m.mem[0]._nrbits
+            for s in m.mem:
+                vals.append('{}\'d{}'.format(w, _intRepr(s._init)))
 
-        print("%s %s%s%s [0:%s-1];" % (k, p, r, m.name, m.depth),
-              file=f)
+            print('localparam {} {} {} [0:{}-1] = {{{}}};'.format(p, r, m.name, m.depth, ', '.join(vals)), file=f)
 
         if initial_assignments is not None:
             print(initial_assignments, file=f)
@@ -1100,11 +1113,11 @@ class _ConvertVisitor(ast.NodeVisitor, _ConversionMixin):
             self.write("default")
         else:
             raise AssertionError("Unknown name %s or pattern %s" % (node.name, node.pattern))
-    
+
     def visit_MatchOr(self, node):
         for i, pattern in enumerate(node.patterns):
             self.visit(pattern)
-            if not i == len(node.patterns)-1:
+            if not i == len(node.patterns) - 1:
                 self.write(" | ")
 
     def mapToCase(self, node, *args):

--- a/myhdl/conversion/_verify.py
+++ b/myhdl/conversion/_verify.py
@@ -15,7 +15,7 @@ from myhdl._block import _Block
 
 _version = myhdl.__version__.replace('.', '')
 # strip 'dev' for version
-_version = _version.replace('dev', '')
+_version = _version.replace('dev', '')[:-2]
 
 _simulators = {}
 

--- a/myhdl/test/conversion/general/test_set_dir.py
+++ b/myhdl/test/conversion/general/test_set_dir.py
@@ -7,7 +7,7 @@ from myhdl import (block, Signal, intbv, always, toVHDL, toVerilog)
 
 from myhdl import __version__
 _version = __version__.replace('.', '')
-_shortversion = _version.replace('dev', '')
+_shortversion = _version.replace('dev', '')[:-2]
 
 
 @block


### PR DESCRIPTION
This PR adds true **Constants**
```python
MyConst = Constant(intbv(42)[8:])
```
will convert to:
VHDL:
```VHDL
constant MyConst : unsigned(8 - 1 downto 0) := 8X"2a" ; /* 42 */
```
and
Verilog:
```Verilog
localparam [7:0] MyConst  = 8'd42;
```

It also converts a list of Constants:
```python
A = [Constant(intbv(random.randint(1, 2 ** WIDTH_D - 1))[WIDTH_D:]) for __ in range(8)]
```
VHDL:
```VHDL
type t_array_A is array(0 to 8-1) of unsigned(7 downto 0);
constant A: t_array_A := (
    8X"4e",
    8X"b1",
    8X"d8",
    8X"08",
    8X"c6",
    8X"bd",
    8X"8c",
    8X"9e");
```
Verilog:
```Verilog
localparam  [7:0]  A [0:8-1] = {8'd78, 8'd177, 8'd216, 8'd8, 8'd198, 8'd189, 8'd140, 8'd158};
```