### PR TITLE
_toVerilog.py: 'skip_zero_mem_init': added *forgotten* condition

### DIFF
--- a/myhdl/__init__.py
+++ b/myhdl/__init__.py
@@ -49,7 +49,7 @@ traceSignals -- function that enables signal tracing in a VCD file
 toVerilog -- function that converts a design to Verilog
 
 """
-__version__ = "0.11.47"
+__version__ = "0.11.48"
 
 
 class StopSimulation(Exception):

--- a/myhdl/conversion/_toVerilog.py
+++ b/myhdl/conversion/_toVerilog.py
@@ -381,7 +381,7 @@ def _writeSigDecls(f, intf, siglist, memlist):
 
             if toVerilog.initial_values and not k == 'wire':
                 if all([each._init == m.mem[0]._init for each in m.mem]):
-                    if toVerilog.initial_values == 'skip_zero_mem_init':
+                    if toVerilog.initial_values == 'skip_zero_mem_init' and _intRepr(m.mem[0]._init) == 0:
                         pass
                     else:
                         initialize_block_name = ('INITIALIZE_' + m.name).upper()


### PR DESCRIPTION
_toVerilog.py: `'skip_zero_mem_init'`: added *forgotten* condition that the initial value must be zero to be able to skip the generation of the initial block